### PR TITLE
Unify API error output

### DIFF
--- a/docs/integrations_api.yml
+++ b/docs/integrations_api.yml
@@ -212,9 +212,13 @@ definitions:
       error:
         description: Description of the error.
         type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
+        type: string
     example:
       application/json:
-          error: "failed to fetch device"
+          error: "failed to decode device group data: JSON payload is empty"
+          request_id: "f7881e82-0492-49fb-b459-795654e7188a"
   NewDevice:
     description: New device for admission process.
     type: object

--- a/middleware.go
+++ b/middleware.go
@@ -34,6 +34,7 @@ var (
 
 		// logging
 		&requestlog.RequestLogMiddleware{},
+		&requestid.RequestIdMiddleware{},
 		&accesslog.AccessLogMiddleware{Format: accesslog.SimpleLogFormat},
 		&rest.TimerMiddleware{},
 		&rest.RecorderMiddleware{},
@@ -50,13 +51,13 @@ var (
 		// The expected Content-Type is 'application/json'
 		// if the content is non-null
 		&rest.ContentTypeCheckerMiddleware{},
-		&requestid.RequestIdMiddleware{},
 	}
 
 	DefaultProdStack = []rest.Middleware{
 
 		// logging
 		&requestlog.RequestLogMiddleware{},
+		&requestid.RequestIdMiddleware{},
 		&accesslog.AccessLogMiddleware{Format: accesslog.SimpleLogFormat},
 		&rest.TimerMiddleware{},
 		&rest.RecorderMiddleware{},
@@ -71,7 +72,6 @@ var (
 		// The expected Content-Type is 'application/json'
 		// if the content is non-null
 		&rest.ContentTypeCheckerMiddleware{},
-		&requestid.RequestIdMiddleware{},
 	}
 
 	middlewareMap = map[string][]rest.Middleware{

--- a/requestid/middleware.go
+++ b/requestid/middleware.go
@@ -41,7 +41,7 @@ func (mw *RequestIdMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFu
 		logger := requestlog.RequestLoggerFromContext(r.Context())
 		if logger != nil {
 			logger = logger.F(log.Ctx{"request_id": reqId})
-			ctx = context.WithValue(r.Context(), requestlog.ReqLog, logger)
+			ctx = context.WithValue(ctx, requestlog.ReqLog, logger)
 		}
 
 		r = &rest.Request{


### PR DESCRIPTION
Issues: MEN-501

* fix for a bug introduced in MEN-531 (no request id in access log, due to passing wrong context)
* added request id field in error response body

@maciejmrowiec @mchalski 