### PR TITLE
Cleanup API for submitting device for admission

### DIFF
--- a/api_devadm_test.go
+++ b/api_devadm_test.go
@@ -34,7 +34,7 @@ type MockDevAdm struct {
 	mockGetDevice    func(id DeviceID) (*Device, error)
 	mockAcceptDevice func(id DeviceID) error
 	mockRejectDevice func(id DeviceID) error
-	mockAddDevice    func(d Device) error
+	mockSubmitDevice func(d Device) error
 	mockWithContext  func(c context.Context) DevAdmApp
 }
 
@@ -42,8 +42,8 @@ func (mda *MockDevAdm) ListDevices(skip int, limit int, status string) ([]Device
 	return mda.mockListDevices(skip, limit, status)
 }
 
-func (mda *MockDevAdm) AddDevice(dev Device) error {
-	return mda.mockAddDevice(dev)
+func (mda *MockDevAdm) SubmitDevice(dev Device) error {
+	return mda.mockSubmitDevice(dev)
 }
 
 func (mda *MockDevAdm) GetDevice(id DeviceID) (*Device, error) {
@@ -455,53 +455,32 @@ func makeJson(t *testing.T, d interface{}) string {
 	return string(out)
 }
 
-func TestApiDevAdmAddDevice(t *testing.T) {
-	testCases := []struct {
+func TestApiDevAdmSubmitDevice(t *testing.T) {
+	testCases := map[string]struct {
 		req       *http.Request
 		devAdmErr string
 		respCode  int
 		respBody  string
 	}{
-		{
-			//empty body
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"empty body": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				nil),
-			"",
-			400,
-			RestError("failed to decode request body: JSON payload is empty"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("failed to decode request body: JSON payload is empty"),
 		},
-		{
-			//garbled body
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"garbled body": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				"foo bar"),
-			"",
-			400,
-
-			RestError("failed to decode request body: json: cannot unmarshal string into Go value of type main.Device"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("failed to decode request body: json: cannot unmarshal string into Go value of type main.Device"),
 		},
-		{
-			//body formatted ok, all fields present
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
-				map[string]string{
-					"id":  "id-0001",
-					"key": "key-0001",
-					"device_identity": makeJson(t,
-						map[string]string{
-							"mac": "00:00:00:01",
-						}),
-				},
-			),
-			"",
-			201,
-			"",
-		},
-		{
-			//body formatted ok, 'id' missing
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, all fields present": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
 					"key": "key-0001",
 					"device_identity": makeJson(t,
@@ -510,73 +489,63 @@ func TestApiDevAdmAddDevice(t *testing.T) {
 						}),
 				},
 			),
-			"",
-			400,
-			RestError("'id' field required"),
+			devAdmErr: "",
+			respCode:  204,
+			respBody:  "",
 		},
-		{
-			//body formatted ok, 'key' missing
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, 'key' missing": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
-					"id": "id-0001",
 					"device_identity": makeJson(t,
 						map[string]string{
 							"mac": "00:00:00:01",
 						}),
 				},
 			),
-			"",
-			400,
-			RestError("'key' field required"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("'key' field required"),
 		},
-		{
-			//body formatted ok, identity missing
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, identity missing": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
-					"id":  "id-0001",
 					"key": "key-0001",
 				},
 			),
-			"",
-			400,
-			RestError("'device_identity' field required"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("'device_identity' field required"),
 		},
-		{
-			//body formatted ok, identity garbled
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, identity garbled": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
-					"id":              "id-0001",
 					"key":             "key-0001",
 					"device_identity": "{mac: foobar}",
 				},
 			),
-			"",
-			400,
-			RestError("failed to decode attributes data: invalid character 'm' looking for beginning of object key string"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("failed to decode attributes data: invalid character 'm' looking for beginning of object key string"),
 		},
-		{
-			//body formatted ok, identity empty
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, identity empty": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
-					"id":              "id-0001",
 					"key":             "key-0001",
 					"device_identity": "{}",
 				},
 			),
-			"",
-			400,
-			RestError("no attributes provided"),
+			devAdmErr: "",
+			respCode:  400,
+			respBody:  RestError("no attributes provided"),
 		},
-		{
-			//body formatted ok, devadm error
-			test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/devices",
+		"body formatted ok, devadm error": {
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/id-0001",
 				map[string]string{
-					"id":  "id-0001",
 					"key": "key-0001",
 					"device_identity": makeJson(t,
 						map[string]string{
@@ -584,15 +553,16 @@ func TestApiDevAdmAddDevice(t *testing.T) {
 						}),
 				},
 			),
-			"internal error",
-			500,
-			RestError("internal error"),
+			devAdmErr: "internal error",
+			respCode:  500,
+			respBody:  RestError("internal error"),
 		},
 	}
 
-	for _, tc := range testCases {
+	for name, tc := range testCases {
+		t.Logf("test case: %s", name)
 		devadm := MockDevAdm{
-			mockAddDevice: func(d Device) error {
+			mockSubmitDevice: func(d Device) error {
 				if tc.devAdmErr != "" {
 					return errors.New(tc.devAdmErr)
 				}

--- a/docs/integrations_api.yml
+++ b/docs/integrations_api.yml
@@ -77,21 +77,29 @@ paths:
           description: Internal server error.
           schema:
             $ref: "#/definitions/Error"
-    post:
-      summary: Add a new device for admission
+  /devices/{id}:
+    put:
+      summary: Submit a device for admission
       description: |
         Adds the device to the database with a 'pending' admission status.
+        If the device already exists, it changes the device's status to
+        'pending' and updates identity data.
         The user will be able to inspect the device, and either accept, or reject it.
       parameters:
+        - name: id
+          in: path
+          description: Device identifier (SHA256 over identity data).
+          required: true
+          type: string
         - name: device
           in: body
-          description: New device for admission.
+          description: A device for admission.
           required: true
           schema:
             $ref: '#/definitions/NewDevice'
       responses:
-        201:
-          description: New device for admission created.
+        204:
+          description: The device for admission submitted successfully.
         400:
           description: |
               The request body is malformed. See error for details.
@@ -101,7 +109,6 @@ paths:
           description: Internal server error.
           schema:
             $ref: "#/definitions/Error"
-  /devices/{id}:
     get:
       summary: Get the details of a selected device
       description: Returns the details of a particular device.
@@ -223,13 +230,9 @@ definitions:
     description: New device for admission process.
     type: object
     required:
-      - id
       - device_identity
       - key
     properties:
-      id:
-        description: Device identifier (SHA256 over identity data).
-        type: string
       device_identity:
         description: The identity data of the device.
         type: string


### PR DESCRIPTION
`POST /devices` to `PUT /devices/:id`
* updated docs
* changes in api handler
* add device renamed to submit device
* propagate status update to `deviceauth`

Issues: MEN-650

@mchalski @maciejmrowiec 