### PR TITLE
MEN-963: Update API versioning.

### DIFF
--- a/docs/integrations_api.yml
+++ b/docs/integrations_api.yml
@@ -1,13 +1,13 @@
 swagger: '2.0'
 
 info:
-  version: '0.1'
+  version: '1'
   title: Device admission
   description: |
     An API for device admission handling. Intended for use by the web GUI.
 
-basePath: '/api/integrations/0.1/admission'
-host: 'docker.mender.io:8080'
+basePath: '/api/integrations/v1/admission'
+host: 'docker.mender.io'
 schemes:
   - https
 

--- a/middleware.go
+++ b/middleware.go
@@ -22,6 +22,7 @@ import (
 	dlog "github.com/mendersoftware/deviceadm/log"
 	"github.com/mendersoftware/deviceadm/requestid"
 	"github.com/mendersoftware/deviceadm/requestlog"
+	"github.com/mendersoftware/go-lib-micro/customheader"
 )
 
 const (
@@ -83,6 +84,11 @@ var (
 func SetupMiddleware(api *rest.Api, mwtype string) error {
 
 	l := dlog.New(dlog.Ctx{})
+
+	api.Use(&customheader.CustomHeaderMiddleware{
+		HeaderName:  "X-ADMISSION-VERSION",
+		HeaderValue: CreateVersionString(),
+	})
 
 	l.Infof("setting up %s middleware", mwtype)
 

--- a/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package customheader
+
+import "github.com/ant0ine/go-json-rest/rest"
+
+// Add custom HTTP header to all server responses
+type CustomHeaderMiddleware struct {
+	HeaderName  string
+	HeaderValue string
+}
+
+// MiddlewareFunc makes CustomHeaderMiddleware implement the Middleware interface.
+func (c *CustomHeaderMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
+	return func(w rest.ResponseWriter, r *rest.Request) {
+
+		if len(c.HeaderName) > 0 {
+			w.Header().Add(c.HeaderName, c.HeaderValue)
+		}
+
+		// call the handler
+		h(w, r)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -66,6 +66,12 @@
 			"revision": "23b847ebbbdaada7234bf4b3da1e50e601fbf63b"
 		},
 		{
+			"checksumSHA1": "5PDgQnNLCVPQR537rMBdiAPm5aM=",
+			"path": "github.com/mendersoftware/go-lib-micro/customheader",
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
+		},
+		{
 			"checksumSHA1": "i38FeB/pqmU7xcluq/0LHjIwDY8=",
 			"path": "github.com/mendersoftware/mendertesting",
 			"revision": "8f7685eaafcdf5702c7484892858237090f1240a"


### PR DESCRIPTION
Change public routing to v1, v2, v3 schema (v1).
Update documentation.
Remove port 8080 from swagger.
Add service version header returned by API

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>

@mendersoftware/rndity 