### PR TITLE
devauth: client: expect 204 No Content instead of 200 OK

### DIFF
--- a/client_deviceauth.go
+++ b/client_deviceauth.go
@@ -82,7 +82,7 @@ func (d *DevAuthClient) UpdateDevice(dev Device) error {
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode != http.StatusOK {
+	if rsp.StatusCode != http.StatusNoContent {
 		return errors.Errorf("device status update request failed with status %v",
 			rsp.Status)
 	}

--- a/client_deviceauth_test.go
+++ b/client_deviceauth_test.go
@@ -43,7 +43,7 @@ func newMockServer(status int) *httptest.Server {
 }
 
 func TestDevAuthClientReqSuccess(t *testing.T) {
-	s := newMockServer(200)
+	s := newMockServer(http.StatusNoContent)
 	defer s.Close()
 
 	c := NewDevAuthClient(DevAuthClientConfig{
@@ -57,7 +57,7 @@ func TestDevAuthClientReqSuccess(t *testing.T) {
 }
 
 func TestDevAuthClientReqFail(t *testing.T) {
-	s := newMockServer(400)
+	s := newMockServer(http.StatusBadRequest)
 	defer s.Close()
 
 	c := NewDevAuthClient(DevAuthClientConfig{
@@ -77,7 +77,7 @@ func TestDevAuthClientReqUrl(t *testing.T) {
 		// this is just URI endpoint, without host/port/scheme
 		// etc.
 		urlPath = r.URL.Path
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer s.Close()
 
@@ -122,7 +122,7 @@ func TestDevAuthClientTImeout(t *testing.T) {
 		case <-time.After(defaultDevAuthReqTimeout * 2):
 			// don't block longer than default timeout * 2
 		}
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 	}))
 
 	c := NewDevAuthClient(DevAuthClientConfig{

--- a/devadm_test.go
+++ b/devadm_test.go
@@ -96,7 +96,7 @@ func TestDevAdmSubmitDevice(t *testing.T) {
 	db.On("PutDevice", mock.AnythingOfType("*main.Device")).
 		Return(nil)
 
-	d := devadmWithClientForTest(db, http.StatusOK)
+	d := devadmWithClientForTest(db, http.StatusNoContent)
 
 	err := d.SubmitDevice(Device{})
 
@@ -122,7 +122,7 @@ func TestDevAdmSubmitDeviceErr(t *testing.T) {
 	db.On("PutDevice", mock.AnythingOfType("*main.Device")).
 		Return(errors.New("db connection failed"))
 
-	d := devadmWithClientForTest(db, http.StatusOK)
+	d := devadmWithClientForTest(db, http.StatusNoContent)
 
 	err := d.SubmitDevice(Device{})
 
@@ -177,7 +177,7 @@ func TestDevAdmAcceptDevice(t *testing.T) {
 	db.On("PutDevice", mock.AnythingOfType("*main.Device")).
 		Return(nil)
 
-	d := devadmWithClientForTest(db, http.StatusOK)
+	d := devadmWithClientForTest(db, http.StatusNoContent)
 
 	err := d.AcceptDevice("foo")
 
@@ -197,7 +197,7 @@ func TestDevAdmRejectDevice(t *testing.T) {
 	db.On("PutDevice", mock.AnythingOfType("*main.Device")).
 		Return(nil)
 
-	d := devadmWithClientForTest(db, http.StatusOK)
+	d := devadmWithClientForTest(db, http.StatusNoContent)
 
 	err := d.RejectDevice("foo")
 


### PR DESCRIPTION
Device Authentication API /api/0.1.0/devices/:id/status endpoint has changed and
returns 204 No Content now.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 

companion change: https://github.com/mendersoftware/deviceauth/pull/96