### PR TITLE
Do not propagete 'pending' status to devauth on add device request

### DIFF
--- a/devadm.go
+++ b/devadm.go
@@ -70,12 +70,7 @@ func (d *DevAdm) SubmitDevice(dev Device) error {
 	now := time.Now()
 	dev.RequestTime = &now
 
-	err := d.propagateDeviceUpdate(&dev)
-	if err != nil {
-		return err
-	}
-
-	err = d.db.PutDevice(&dev)
+	err := d.db.PutDevice(&dev)
 	if err != nil {
 		return errors.Wrap(err, "failed to put device")
 	}

--- a/devadm_test.go
+++ b/devadm_test.go
@@ -103,20 +103,6 @@ func TestDevAdmSubmitDevice(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDevAdmSubmitDeviceClientErr(t *testing.T) {
-	db := &MockDataStore{}
-	db.On("PutDevice", mock.AnythingOfType("*main.Device")).
-		Return(nil)
-
-	d := devadmWithClientForTest(db, http.StatusBadRequest)
-
-	err := d.SubmitDevice(Device{})
-
-	if assert.Error(t, err) {
-		assert.EqualError(t, err, "failed to propagate device status update: device status update request failed with status 400 Bad Request")
-	}
-}
-
 func TestDevAdmSubmitDeviceErr(t *testing.T) {
 	db := &MockDataStore{}
 	db.On("PutDevice", mock.AnythingOfType("*main.Device")).


### PR DESCRIPTION
Device admission should be responsible for accepting and rejecting devices only.

TODO: update acceptance tests