### PR TITLE
datastore_mongo: fix uniqueDevIdIdx creation

### DIFF
--- a/datastore_mongo.go
+++ b/datastore_mongo.go
@@ -27,7 +27,7 @@ const (
 	DbName        = "deviceadm"
 	DbDevicesColl = "devices"
 
-	DbDeviceIdIndex     = DbDevicesColl + ".id"
+	DbDeviceIdIndex     = "id"
 	DbDeviceIdIndexName = "uniqueDeviceIdIndex"
 )
 


### PR DESCRIPTION
the 'id' field was unnecessarily nested to include collection name.
result: field doesn't exist, is always null, index doesn't allow inserting anything
more than once.

Issues: MEN-987

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

this is a critical bugfix.

@mendersoftware/rndity @maciejmrowiec 