### PR TITLE
support for DELETE /devices?device_id=<did>

### DIFF
--- a/api/http/api_devadm.go
+++ b/api/http/api_devadm.go
@@ -141,8 +141,8 @@ func (d *DevAdmHandlers) SubmitDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func parseDevice(r *rest.Request) (*model.Device, error) {
-	dev := model.Device{}
+func parseDevice(r *rest.Request) (*model.DeviceAuth, error) {
+	dev := model.DeviceAuth{}
 
 	//decode body
 	err := r.DecodeJsonPayload(&dev)
@@ -187,7 +187,7 @@ func parseDevice(r *rest.Request) (*model.Device, error) {
 // request 'r' and return it. If a device was not found returns nil
 // and produces a sutabie error response using provided
 // rest.ResponseWriter
-func (d *DevAdmHandlers) getDeviceOrFail(w rest.ResponseWriter, r *rest.Request) *model.Device {
+func (d *DevAdmHandlers) getDeviceOrFail(w rest.ResponseWriter, r *rest.Request) *model.DeviceAuth {
 	l := requestlog.GetRequestLogger(r.Env)
 
 	authid := r.PathParam("id")

--- a/api/http/api_devadm.go
+++ b/api/http/api_devadm.go
@@ -196,7 +196,7 @@ func (d *DevAdmHandlers) getDeviceOrFail(w rest.ResponseWriter, r *rest.Request)
 	dev, err := da.GetDevice(model.AuthID(authid))
 
 	if dev == nil {
-		if err == store.ErrDevNotFound {
+		if err == store.ErrNotFound {
 			restErrWithLog(w, r, l, err, http.StatusNotFound)
 		} else {
 			restErrWithLogInternal(w, r, l, err)
@@ -243,7 +243,7 @@ func (d *DevAdmHandlers) UpdateDeviceStatusHandler(w rest.ResponseWriter, r *res
 		err = da.RejectDevice(model.AuthID(authid))
 	}
 	if err != nil {
-		if err == store.ErrDevNotFound {
+		if err == store.ErrNotFound {
 			restErrWithLog(w, r, l, err, http.StatusNotFound)
 		} else {
 			restErrWithLogInternal(w, r, l, errors.Wrap(err, "failed to list change device status"))
@@ -277,8 +277,8 @@ func (d *DevAdmHandlers) DeleteDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 	switch err {
 	case nil:
 		w.WriteHeader(http.StatusNoContent)
-	case store.ErrDevNotFound:
-		restErrWithLog(w, r, l, store.ErrDevNotFound, http.StatusNotFound)
+	case store.ErrNotFound:
+		restErrWithLog(w, r, l, store.ErrNotFound, http.StatusNotFound)
 	default:
 		restErrWithLogInternal(w, r, l, err)
 	}

--- a/api/http/api_devadm.go
+++ b/api/http/api_devadm.go
@@ -98,7 +98,7 @@ func (d *DevAdmHandlers) GetDevicesHandler(w rest.ResponseWriter, r *rest.Reques
 	da := d.DevAdm.WithContext(restToContext(r))
 
 	//get one extra device to see if there's a 'next' page
-	devs, err := da.ListDevices(int((page-1)*perPage), int(perPage+1), status)
+	devs, err := da.ListDeviceAuths(int((page-1)*perPage), int(perPage+1), status)
 	if err != nil {
 		restErrWithLogInternal(w, r, l, errors.Wrap(err, "failed to list devices"))
 		return
@@ -132,7 +132,7 @@ func (d *DevAdmHandlers) SubmitDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 
 	//save device in pending state
 	dev.Status = "pending"
-	err = da.SubmitDevice(*dev)
+	err = da.SubmitDeviceAuth(*dev)
 	if err != nil {
 		restErrWithLogInternal(w, r, l, err)
 		return
@@ -193,7 +193,7 @@ func (d *DevAdmHandlers) getDeviceOrFail(w rest.ResponseWriter, r *rest.Request)
 	authid := r.PathParam("id")
 
 	da := d.DevAdm.WithContext(restToContext(r))
-	dev, err := da.GetDevice(model.AuthID(authid))
+	dev, err := da.GetDeviceAuth(model.AuthID(authid))
 
 	if dev == nil {
 		if err == store.ErrNotFound {
@@ -238,9 +238,9 @@ func (d *DevAdmHandlers) UpdateDeviceStatusHandler(w rest.ResponseWriter, r *res
 	da := d.DevAdm.WithContext(restToContext(r))
 
 	if status.Status == model.DevStatusAccepted {
-		err = da.AcceptDevice(model.AuthID(authid))
+		err = da.AcceptDeviceAuth(model.AuthID(authid))
 	} else if status.Status == model.DevStatusRejected {
-		err = da.RejectDevice(model.AuthID(authid))
+		err = da.RejectDeviceAuth(model.AuthID(authid))
 	}
 	if err != nil {
 		if err == store.ErrNotFound {
@@ -272,7 +272,7 @@ func (d *DevAdmHandlers) DeleteDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 	devid := r.PathParam("id")
 
 	da := d.DevAdm.WithContext(restToContext(r))
-	err := da.DeleteDevice(model.AuthID(devid))
+	err := da.DeleteDeviceAuth(model.AuthID(devid))
 
 	switch err {
 	case nil:

--- a/api/http/api_devadm.go
+++ b/api/http/api_devadm.go
@@ -132,14 +132,13 @@ func (d *DevAdmHandlers) DeleteDevicesHandler(w rest.ResponseWriter, r *rest.Req
 	da := d.DevAdm.WithContext(restToContext(r))
 
 	err = da.DeleteDeviceData(model.DeviceID(devid))
-	switch {
-	case err == store.ErrNotFound:
-		restErrWithLog(w, r, l, err, http.StatusNotFound)
-	case err != nil:
+
+	if err != nil && err != store.ErrNotFound {
 		restErrWithLogInternal(w, r, l, err)
-	default:
-		w.WriteHeader(http.StatusNoContent)
+		return
 	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (d *DevAdmHandlers) SubmitDeviceHandler(w rest.ResponseWriter, r *rest.Request) {
@@ -297,16 +296,12 @@ func (d *DevAdmHandlers) DeleteDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 	da := d.DevAdm.WithContext(restToContext(r))
 	err := da.DeleteDeviceAuth(model.AuthID(devid))
 
-	switch err {
-	case nil:
-		w.WriteHeader(http.StatusNoContent)
-	case store.ErrNotFound:
-		restErrWithLog(w, r, l, store.ErrNotFound, http.StatusNotFound)
-	default:
+	if err != nil && err != store.ErrNotFound {
 		restErrWithLogInternal(w, r, l, err)
+		return
 	}
 
-	return
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // return selected http code + error message directly taken from error

--- a/api/http/api_devadm_test.go
+++ b/api/http/api_devadm_test.go
@@ -293,7 +293,7 @@ func TestApiDevAdmGetDevice(t *testing.T) {
 		mockGetDevice: func(id model.AuthID) (*model.DeviceAuth, error) {
 			d, ok := devs[id.String()]
 			if ok == false {
-				return nil, store.ErrDevNotFound
+				return nil, store.ErrNotFound
 			}
 			if d.err != nil {
 				return nil, d.err
@@ -338,12 +338,12 @@ func TestApiDevAdmGetDevice(t *testing.T) {
 			test.MakeSimpleRequest("GET",
 				"http://1.2.3.4/api/0.1.0/devices/baz", nil),
 			404,
-			RestError(store.ErrDevNotFound.Error()),
+			RestError(store.ErrNotFound.Error()),
 		},
 		{
 			test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices/baz/status", nil),
 			404,
-			RestError(store.ErrDevNotFound.Error()),
+			RestError(store.ErrNotFound.Error()),
 		},
 	}
 
@@ -376,7 +376,7 @@ func TestApiDevAdmUpdateStatusDevice(t *testing.T) {
 	mockaction := func(id model.AuthID) error {
 		d, ok := devs[id.String()]
 		if ok == false {
-			return store.ErrDevNotFound
+			return store.ErrNotFound
 		}
 		if d.err != nil {
 			return d.err
@@ -432,7 +432,7 @@ func TestApiDevAdmUpdateStatusDevice(t *testing.T) {
 				"http://1.2.3.4/api/0.1.0/devices/baz/status",
 				accstatus),
 			code: 404,
-			body: RestError(store.ErrDevNotFound.Error()),
+			body: RestError(store.ErrNotFound.Error()),
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
@@ -637,10 +637,10 @@ func TestApiDeleteDevice(t *testing.T) {
 		"error: no device": {
 			req: test.MakeSimpleRequest("DELETE", "http://1.2.3.4/api/0.1.0/devices/1", nil),
 
-			devadmErr: store.ErrDevNotFound,
+			devadmErr: store.ErrNotFound,
 
 			code: http.StatusNotFound,
-			body: RestError(store.ErrDevNotFound.Error()),
+			body: RestError(store.ErrNotFound.Error()),
 		},
 		"error: generic": {
 			req: test.MakeSimpleRequest("DELETE", "http://1.2.3.4/api/0.1.0/devices/3", nil),

--- a/api/http/api_devadm_test.go
+++ b/api/http/api_devadm_test.go
@@ -35,44 +35,44 @@ import (
 )
 
 type MockDevAdm struct {
-	mockListDevices  func(skip int, limit int, status string) ([]model.DeviceAuth, error)
-	mockGetDevice    func(id model.AuthID) (*model.DeviceAuth, error)
-	mockAcceptDevice func(id model.AuthID) error
-	mockRejectDevice func(id model.AuthID) error
-	mockSubmitDevice func(d model.DeviceAuth) error
-	mockDeleteDevice func(id model.AuthID) error
-	mockWithContext  func(c context.Context) devadm.DevAdmApp
+	mockListDeviceAuths  func(skip int, limit int, status string) ([]model.DeviceAuth, error)
+	mockGetDeviceAuth    func(id model.AuthID) (*model.DeviceAuth, error)
+	mockAcceptDeviceAuth func(id model.AuthID) error
+	mockRejectDeviceAuth func(id model.AuthID) error
+	mockSubmitDeviceAuth func(d model.DeviceAuth) error
+	mockDeleteDeviceAuth func(id model.AuthID) error
+	mockWithContext      func(c context.Context) devadm.DevAdmApp
 }
 
-func (mda *MockDevAdm) ListDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
-	return mda.mockListDevices(skip, limit, status)
+func (mda *MockDevAdm) ListDeviceAuths(skip int, limit int, status string) ([]model.DeviceAuth, error) {
+	return mda.mockListDeviceAuths(skip, limit, status)
 }
 
-func (mda *MockDevAdm) SubmitDevice(dev model.DeviceAuth) error {
-	return mda.mockSubmitDevice(dev)
+func (mda *MockDevAdm) SubmitDeviceAuth(dev model.DeviceAuth) error {
+	return mda.mockSubmitDeviceAuth(dev)
 }
 
-func (mda *MockDevAdm) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
-	return mda.mockGetDevice(id)
+func (mda *MockDevAdm) GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, error) {
+	return mda.mockGetDeviceAuth(id)
 }
 
-func (mda *MockDevAdm) AcceptDevice(id model.AuthID) error {
-	return mda.mockAcceptDevice(id)
+func (mda *MockDevAdm) AcceptDeviceAuth(id model.AuthID) error {
+	return mda.mockAcceptDeviceAuth(id)
 }
 
-func (mda *MockDevAdm) RejectDevice(id model.AuthID) error {
-	return mda.mockRejectDevice(id)
+func (mda *MockDevAdm) RejectDeviceAuth(id model.AuthID) error {
+	return mda.mockRejectDeviceAuth(id)
 }
 
-func (mda *MockDevAdm) DeleteDevice(id model.AuthID) error {
-	return mda.mockDeleteDevice(id)
+func (mda *MockDevAdm) DeleteDeviceAuth(id model.AuthID) error {
+	return mda.mockDeleteDeviceAuth(id)
 }
 
 func (mda *MockDevAdm) WithContext(c context.Context) devadm.DevAdmApp {
 	return mda
 }
 
-func mockListDevices(num int) []model.DeviceAuth {
+func mockListDeviceAuths(num int) []model.DeviceAuth {
 	var devs []model.DeviceAuth
 	for i := 0; i < num; i++ {
 		devs = append(devs, model.DeviceAuth{
@@ -140,7 +140,7 @@ func TestApiDevAdmGetDevices(t *testing.T) {
 			nil,
 			test.MakeSimpleRequest("GET", "http://1.2.3.4/r?page=4&per_page=5", nil),
 			200,
-			ToJson(mockListDevices(5)),
+			ToJson(mockListDeviceAuths(5)),
 			[]string{
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=3&per_page=5", "prev"),
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=1&per_page=5", "first"),
@@ -152,7 +152,7 @@ func TestApiDevAdmGetDevices(t *testing.T) {
 			nil,
 			test.MakeSimpleRequest("GET", "http://1.2.3.4/r?page=4&per_page=5", nil),
 			200,
-			ToJson(mockListDevices(5)),
+			ToJson(mockListDeviceAuths(5)),
 			[]string{
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=3&per_page=5", "prev"),
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=1&per_page=5", "first"),
@@ -191,7 +191,7 @@ func TestApiDevAdmGetDevices(t *testing.T) {
 			nil,
 			test.MakeSimpleRequest("GET", "http://1.2.3.4/r?page=4&per_page=5&status=allowed", nil),
 			200,
-			ToJson(mockListDevices(5)),
+			ToJson(mockListDeviceAuths(5)),
 			[]string{
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=3&per_page=5&status=allowed", "prev"),
 				fmt.Sprintf(utils.LinkTmpl, "r", "page=1&per_page=5&status=allowed", "first"),
@@ -219,12 +219,12 @@ func TestApiDevAdmGetDevices(t *testing.T) {
 
 	for _, testCase := range testCases {
 		devadm := MockDevAdm{
-			mockListDevices: func(skip int, limit int, status string) ([]model.DeviceAuth, error) {
+			mockListDeviceAuths: func(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 				if testCase.listDevicesErr != nil {
 					return nil, testCase.listDevicesErr
 				}
 
-				return mockListDevices(testCase.listDevicesNum), nil
+				return mockListDeviceAuths(testCase.listDevicesNum), nil
 			},
 		}
 
@@ -290,7 +290,7 @@ func TestApiDevAdmGetDevice(t *testing.T) {
 	}
 
 	devadm := MockDevAdm{
-		mockGetDevice: func(id model.AuthID) (*model.DeviceAuth, error) {
+		mockGetDeviceAuth: func(id model.AuthID) (*model.DeviceAuth, error) {
 			d, ok := devs[id.String()]
 			if ok == false {
 				return nil, store.ErrNotFound
@@ -384,8 +384,8 @@ func TestApiDevAdmUpdateStatusDevice(t *testing.T) {
 		return nil
 	}
 	devadm := MockDevAdm{
-		mockAcceptDevice: mockaction,
-		mockRejectDevice: mockaction,
+		mockAcceptDeviceAuth: mockaction,
+		mockRejectDeviceAuth: mockaction,
 	}
 
 	apih := makeMockApiHandler(t, &devadm)
@@ -598,7 +598,7 @@ func TestApiDevAdmSubmitDevice(t *testing.T) {
 	for name, tc := range testCases {
 		t.Logf("test case: %s", name)
 		devadm := MockDevAdm{
-			mockSubmitDevice: func(d model.DeviceAuth) error {
+			mockSubmitDeviceAuth: func(d model.DeviceAuth) error {
 				if tc.devAdmErr != "" {
 					return errors.New(tc.devAdmErr)
 				}
@@ -655,7 +655,7 @@ func TestApiDeleteDevice(t *testing.T) {
 	for name, tc := range tcases {
 		t.Run(fmt.Sprintf("test case: %s", name), func(t *testing.T) {
 			devadm := MockDevAdm{
-				mockDeleteDevice: func(id model.AuthID) error {
+				mockDeleteDeviceAuth: func(id model.AuthID) error {
 					return tc.devadmErr
 				},
 			}

--- a/api/http/api_devadm_test.go
+++ b/api/http/api_devadm_test.go
@@ -644,8 +644,7 @@ func TestApiDeleteDevice(t *testing.T) {
 
 			devadmErr: store.ErrNotFound,
 
-			code: http.StatusNotFound,
-			body: RestError(store.ErrNotFound.Error()),
+			code: http.StatusNoContent,
 		},
 		"error: generic": {
 			req: test.MakeSimpleRequest("DELETE", "http://1.2.3.4/api/0.1.0/devices/3", nil),
@@ -700,8 +699,7 @@ func TestApiDeleteDeviceData(t *testing.T) {
 			devadmErr: store.ErrNotFound,
 			devid:     "1",
 
-			code: http.StatusNotFound,
-			body: RestError(store.ErrNotFound.Error()),
+			code: http.StatusNoContent,
 		},
 		"error: generic": {
 			req: test.MakeSimpleRequest("DELETE", "http://1.2.3.4/api/0.1.0/devices?device_id=3", nil),

--- a/api/http/api_devadm_test.go
+++ b/api/http/api_devadm_test.go
@@ -35,24 +35,24 @@ import (
 )
 
 type MockDevAdm struct {
-	mockListDevices  func(skip int, limit int, status string) ([]model.Device, error)
-	mockGetDevice    func(id model.AuthID) (*model.Device, error)
+	mockListDevices  func(skip int, limit int, status string) ([]model.DeviceAuth, error)
+	mockGetDevice    func(id model.AuthID) (*model.DeviceAuth, error)
 	mockAcceptDevice func(id model.AuthID) error
 	mockRejectDevice func(id model.AuthID) error
-	mockSubmitDevice func(d model.Device) error
+	mockSubmitDevice func(d model.DeviceAuth) error
 	mockDeleteDevice func(id model.AuthID) error
 	mockWithContext  func(c context.Context) devadm.DevAdmApp
 }
 
-func (mda *MockDevAdm) ListDevices(skip int, limit int, status string) ([]model.Device, error) {
+func (mda *MockDevAdm) ListDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 	return mda.mockListDevices(skip, limit, status)
 }
 
-func (mda *MockDevAdm) SubmitDevice(dev model.Device) error {
+func (mda *MockDevAdm) SubmitDevice(dev model.DeviceAuth) error {
 	return mda.mockSubmitDevice(dev)
 }
 
-func (mda *MockDevAdm) GetDevice(id model.AuthID) (*model.Device, error) {
+func (mda *MockDevAdm) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 	return mda.mockGetDevice(id)
 }
 
@@ -72,10 +72,10 @@ func (mda *MockDevAdm) WithContext(c context.Context) devadm.DevAdmApp {
 	return mda
 }
 
-func mockListDevices(num int) []model.Device {
-	var devs []model.Device
+func mockListDevices(num int) []model.DeviceAuth {
+	var devs []model.DeviceAuth
 	for i := 0; i < num; i++ {
-		devs = append(devs, model.Device{
+		devs = append(devs, model.DeviceAuth{
 			ID:       model.AuthID(strconv.Itoa(i)),
 			DeviceId: model.DeviceID(strconv.Itoa(i)),
 		})
@@ -219,7 +219,7 @@ func TestApiDevAdmGetDevices(t *testing.T) {
 
 	for _, testCase := range testCases {
 		devadm := MockDevAdm{
-			mockListDevices: func(skip int, limit int, status string) ([]model.Device, error) {
+			mockListDevices: func(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 				if testCase.listDevicesErr != nil {
 					return nil, testCase.listDevicesErr
 				}
@@ -271,11 +271,11 @@ func makeMockApiHandler(t *testing.T, mocka *MockDevAdm) http.Handler {
 
 func TestApiDevAdmGetDevice(t *testing.T) {
 	devs := map[string]struct {
-		dev *model.Device
+		dev *model.DeviceAuth
 		err error
 	}{
 		"foo": {
-			&model.Device{
+			&model.DeviceAuth{
 				ID:             "foo",
 				Key:            "foobar",
 				Status:         "accepted",
@@ -290,7 +290,7 @@ func TestApiDevAdmGetDevice(t *testing.T) {
 	}
 
 	devadm := MockDevAdm{
-		mockGetDevice: func(id model.AuthID) (*model.Device, error) {
+		mockGetDevice: func(id model.AuthID) (*model.DeviceAuth, error) {
 			d, ok := devs[id.String()]
 			if ok == false {
 				return nil, store.ErrDevNotFound
@@ -354,11 +354,11 @@ func TestApiDevAdmGetDevice(t *testing.T) {
 
 func TestApiDevAdmUpdateStatusDevice(t *testing.T) {
 	devs := map[string]struct {
-		dev *model.Device
+		dev *model.DeviceAuth
 		err error
 	}{
 		"foo": {
-			&model.Device{
+			&model.DeviceAuth{
 				ID:             "foo",
 				DeviceId:       "bar",
 				Key:            "foobar",
@@ -491,7 +491,7 @@ func TestApiDevAdmSubmitDevice(t *testing.T) {
 				"foo bar"),
 			devAdmErr: "",
 			respCode:  400,
-			respBody:  RestError("failed to decode request body: json: cannot unmarshal string into Go value of type model.Device"),
+			respBody:  RestError("failed to decode request body: json: cannot unmarshal string into Go value of type model.DeviceAuth"),
 		},
 		"body formatted ok, all fields present": {
 			req: test.MakeSimpleRequest("PUT",
@@ -598,7 +598,7 @@ func TestApiDevAdmSubmitDevice(t *testing.T) {
 	for name, tc := range testCases {
 		t.Logf("test case: %s", name)
 		devadm := MockDevAdm{
-			mockSubmitDevice: func(d model.Device) error {
+			mockSubmitDevice: func(d model.DeviceAuth) error {
 				if tc.devAdmErr != "" {
 					return errors.New(tc.devAdmErr)
 				}

--- a/devadm/devadm.go
+++ b/devadm/devadm.go
@@ -36,9 +36,9 @@ func simpleApiClientGetter() requestid.ApiRequester {
 
 // this device admission service interface
 type DevAdmApp interface {
-	ListDevices(skip int, limit int, status string) ([]model.Device, error)
-	SubmitDevice(d model.Device) error
-	GetDevice(id model.AuthID) (*model.Device, error)
+	ListDevices(skip int, limit int, status string) ([]model.DeviceAuth, error)
+	SubmitDevice(d model.DeviceAuth) error
+	GetDevice(id model.AuthID) (*model.DeviceAuth, error)
 	AcceptDevice(id model.AuthID) error
 	RejectDevice(id model.AuthID) error
 	DeleteDevice(id model.AuthID) error
@@ -62,7 +62,7 @@ type DevAdm struct {
 	clientGetter   ApiClientGetter
 }
 
-func (d *DevAdm) ListDevices(skip int, limit int, status string) ([]model.Device, error) {
+func (d *DevAdm) ListDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 	devs, err := d.db.GetDevices(skip, limit, status)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch devices")
@@ -71,7 +71,7 @@ func (d *DevAdm) ListDevices(skip int, limit int, status string) ([]model.Device
 	return devs, nil
 }
 
-func (d *DevAdm) SubmitDevice(dev model.Device) error {
+func (d *DevAdm) SubmitDevice(dev model.DeviceAuth) error {
 	now := time.Now()
 	dev.RequestTime = &now
 
@@ -82,7 +82,7 @@ func (d *DevAdm) SubmitDevice(dev model.Device) error {
 	return nil
 }
 
-func (d *DevAdm) GetDevice(id model.AuthID) (*model.Device, error) {
+func (d *DevAdm) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 	dev, err := d.db.GetDevice(id)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (d *DevAdm) DeleteDevice(id model.AuthID) error {
 	}
 }
 
-func (d *DevAdm) propagateDeviceUpdate(dev *model.Device) error {
+func (d *DevAdm) propagateDeviceUpdate(dev *model.DeviceAuth) error {
 	// forward device state to auth service
 	cl := deviceauth.NewClientWithLogger(d.authclientconf, d.clientGetter(), d.log)
 	err := cl.UpdateDevice(deviceauth.StatusReq{
@@ -132,7 +132,7 @@ func (d *DevAdm) updateDeviceStatus(id model.AuthID, status string) error {
 	}
 
 	// update only status and attributes fields
-	err = d.db.PutDevice(&model.Device{
+	err = d.db.PutDevice(&model.DeviceAuth{
 		ID:       dev.ID,
 		DeviceId: dev.DeviceId,
 		Status:   dev.Status,

--- a/devadm/devadm.go
+++ b/devadm/devadm.go
@@ -43,6 +43,8 @@ type DevAdmApp interface {
 	RejectDeviceAuth(id model.AuthID) error
 	DeleteDeviceAuth(id model.AuthID) error
 
+	DeleteDeviceData(id model.DeviceID) error
+
 	WithContext(c context.Context) DevAdmApp
 }
 
@@ -150,6 +152,10 @@ func (d *DevAdm) AcceptDeviceAuth(id model.AuthID) error {
 
 func (d *DevAdm) RejectDeviceAuth(id model.AuthID) error {
 	return d.updateDeviceAuthStatus(id, model.DevStatusRejected)
+}
+
+func (d *DevAdm) DeleteDeviceData(devid model.DeviceID) error {
+	return d.db.DeleteDeviceAuthByDevice(devid)
 }
 
 func (d *DevAdm) WithContext(ctx context.Context) DevAdmApp {

--- a/devadm/devadm.go
+++ b/devadm/devadm.go
@@ -63,7 +63,7 @@ type DevAdm struct {
 }
 
 func (d *DevAdm) ListDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
-	devs, err := d.db.GetDevices(skip, limit, status)
+	devs, err := d.db.GetDeviceAuths(skip, limit, status)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch devices")
 	}
@@ -75,7 +75,7 @@ func (d *DevAdm) SubmitDevice(dev model.DeviceAuth) error {
 	now := time.Now()
 	dev.RequestTime = &now
 
-	err := d.db.PutDevice(&dev)
+	err := d.db.PutDeviceAuth(&dev)
 	if err != nil {
 		return errors.Wrap(err, "failed to put device")
 	}
@@ -83,7 +83,7 @@ func (d *DevAdm) SubmitDevice(dev model.DeviceAuth) error {
 }
 
 func (d *DevAdm) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
-	dev, err := d.db.GetDevice(id)
+	dev, err := d.db.GetDeviceAuth(id)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (d *DevAdm) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 }
 
 func (d *DevAdm) DeleteDevice(id model.AuthID) error {
-	err := d.db.DeleteDevice(id)
+	err := d.db.DeleteDeviceAuth(id)
 	switch err {
 	case nil:
 		return nil
@@ -119,7 +119,7 @@ func (d *DevAdm) propagateDeviceUpdate(dev *model.DeviceAuth) error {
 }
 
 func (d *DevAdm) updateDeviceStatus(id model.AuthID, status string) error {
-	dev, err := d.db.GetDevice(id)
+	dev, err := d.db.GetDeviceAuth(id)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (d *DevAdm) updateDeviceStatus(id model.AuthID, status string) error {
 	}
 
 	// update only status and attributes fields
-	err = d.db.PutDevice(&model.DeviceAuth{
+	err = d.db.PutDeviceAuth(&model.DeviceAuth{
 		ID:       dev.ID,
 		DeviceId: dev.DeviceId,
 		Status:   dev.Status,

--- a/devadm/devadm.go
+++ b/devadm/devadm.go
@@ -95,7 +95,7 @@ func (d *DevAdm) DeleteDevice(id model.AuthID) error {
 	switch err {
 	case nil:
 		return nil
-	case store.ErrDevNotFound:
+	case store.ErrNotFound:
 		return err
 	default:
 		return errors.Wrap(err, "failed to delete device")

--- a/devadm/devadm_test.go
+++ b/devadm/devadm_test.go
@@ -67,7 +67,7 @@ func devadmForTest(d store.DataStore) DevAdmApp {
 func TestDevAdmListDevicesEmpty(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevices", 0, 1, "").
-		Return([]model.Device{}, nil)
+		Return([]model.DeviceAuth{}, nil)
 
 	d := devadmForTest(db)
 
@@ -78,7 +78,7 @@ func TestDevAdmListDevicesEmpty(t *testing.T) {
 func TestDevAdmListDevices(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevices", 0, 1, "").
-		Return([]model.Device{{}, {}, {}}, nil)
+		Return([]model.DeviceAuth{{}, {}, {}}, nil)
 
 	d := devadmForTest(db)
 
@@ -89,7 +89,7 @@ func TestDevAdmListDevices(t *testing.T) {
 func TestDevAdmListDevicesErr(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevices", 0, 1, "").
-		Return([]model.Device{}, errors.New("error"))
+		Return([]model.DeviceAuth{}, errors.New("error"))
 
 	d := devadmForTest(db)
 
@@ -99,32 +99,32 @@ func TestDevAdmListDevicesErr(t *testing.T) {
 
 func TestDevAdmSubmitDevice(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("PutDevice", mock.AnythingOfType("*model.Device")).
+	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.SubmitDevice(model.Device{})
+	err := d.SubmitDevice(model.DeviceAuth{})
 
 	assert.NoError(t, err)
 }
 
 func TestDevAdmSubmitDeviceErr(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("PutDevice", mock.AnythingOfType("*model.Device")).
+	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(errors.New("db connection failed"))
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.SubmitDevice(model.Device{})
+	err := d.SubmitDevice(model.DeviceAuth{})
 
 	if assert.Error(t, err) {
 		assert.EqualError(t, err, "failed to put device: db connection failed")
 	}
 }
 
-func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.Device, error) {
-	return func(aid model.AuthID) (*model.Device, error) {
+func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.DeviceAuth, error) {
+	return func(aid model.AuthID) (*model.DeviceAuth, error) {
 		if aid == "" {
 			return nil, errors.New("unsupported device auth ID")
 		}
@@ -132,7 +132,7 @@ func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.Device, error)
 		if aid != id {
 			return nil, store.ErrDevNotFound
 		}
-		return &model.Device{
+		return &model.DeviceAuth{
 			ID:       id,
 			DeviceId: model.DeviceID(id),
 		}, nil
@@ -142,7 +142,7 @@ func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.Device, error)
 func TestDevAdmGetDevice(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevice", model.AuthID("foo")).
-		Return(&model.Device{ID: "foo", DeviceId: "foo"}, nil)
+		Return(&model.DeviceAuth{ID: "foo", DeviceId: "foo"}, nil)
 	db.On("GetDevice", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
 	db.On("GetDevice", model.AuthID("baz")).
@@ -166,10 +166,10 @@ func TestDevAdmGetDevice(t *testing.T) {
 func TestDevAdmAcceptDevice(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevice", model.AuthID("foo")).
-		Return(&model.Device{ID: "foo"}, nil)
+		Return(&model.DeviceAuth{ID: "foo"}, nil)
 	db.On("GetDevice", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
-	db.On("PutDevice", mock.AnythingOfType("*model.Device")).
+	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
@@ -229,10 +229,10 @@ func TestDevAdmDeleteDevice(t *testing.T) {
 func TestDevAdmRejectDevice(t *testing.T) {
 	db := &mstore.DataStore{}
 	db.On("GetDevice", model.AuthID("foo")).
-		Return(&model.Device{ID: "foo"}, nil)
+		Return(&model.DeviceAuth{ID: "foo"}, nil)
 	db.On("GetDevice", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
-	db.On("PutDevice", mock.AnythingOfType("*model.Device")).
+	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)

--- a/devadm/devadm_test.go
+++ b/devadm/devadm_test.go
@@ -130,7 +130,7 @@ func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.DeviceAuth, er
 		}
 
 		if aid != id {
-			return nil, store.ErrDevNotFound
+			return nil, store.ErrNotFound
 		}
 		return &model.DeviceAuth{
 			ID:       id,
@@ -144,7 +144,7 @@ func TestDevAdmGetDevice(t *testing.T) {
 	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo", DeviceId: "foo"}, nil)
 	db.On("GetDeviceAuth", model.AuthID("bar")).
-		Return(nil, store.ErrDevNotFound)
+		Return(nil, store.ErrNotFound)
 	db.On("GetDeviceAuth", model.AuthID("baz")).
 		Return(nil, errors.New("error"))
 
@@ -156,7 +156,7 @@ func TestDevAdmGetDevice(t *testing.T) {
 
 	dev, err = d.GetDevice("bar")
 	assert.Nil(t, dev)
-	assert.EqualError(t, err, store.ErrDevNotFound.Error())
+	assert.EqualError(t, err, store.ErrNotFound.Error())
 
 	dev, err = d.GetDevice("baz")
 	assert.Nil(t, dev)
@@ -168,7 +168,7 @@ func TestDevAdmAcceptDevice(t *testing.T) {
 	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo"}, nil)
 	db.On("GetDeviceAuth", model.AuthID("bar")).
-		Return(nil, store.ErrDevNotFound)
+		Return(nil, store.ErrNotFound)
 	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
@@ -180,7 +180,7 @@ func TestDevAdmAcceptDevice(t *testing.T) {
 
 	err = d.AcceptDevice("bar")
 	assert.Error(t, err)
-	assert.EqualError(t, err, store.ErrDevNotFound.Error())
+	assert.EqualError(t, err, store.ErrNotFound.Error())
 }
 
 func TestDevAdmDeleteDevice(t *testing.T) {
@@ -195,8 +195,8 @@ func TestDevAdmDeleteDevice(t *testing.T) {
 			outError:       nil,
 		},
 		"no device": {
-			datastoreError: store.ErrDevNotFound,
-			outError:       store.ErrDevNotFound,
+			datastoreError: store.ErrNotFound,
+			outError:       store.ErrNotFound,
 		},
 		"datastore error": {
 			datastoreError: errors.New("db connection failed"),
@@ -231,7 +231,7 @@ func TestDevAdmRejectDevice(t *testing.T) {
 	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo"}, nil)
 	db.On("GetDeviceAuth", model.AuthID("bar")).
-		Return(nil, store.ErrDevNotFound)
+		Return(nil, store.ErrNotFound)
 	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
@@ -243,7 +243,7 @@ func TestDevAdmRejectDevice(t *testing.T) {
 
 	err = d.RejectDevice("bar")
 	assert.Error(t, err)
-	assert.EqualError(t, err, store.ErrDevNotFound.Error())
+	assert.EqualError(t, err, store.ErrNotFound.Error())
 }
 
 func TestNewDevAdm(t *testing.T) {

--- a/devadm/devadm_test.go
+++ b/devadm/devadm_test.go
@@ -66,7 +66,7 @@ func devadmForTest(d store.DataStore) DevAdmApp {
 
 func TestDevAdmListDevicesEmpty(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevices", 0, 1, "").
+	db.On("GetDeviceAuths", 0, 1, "").
 		Return([]model.DeviceAuth{}, nil)
 
 	d := devadmForTest(db)
@@ -77,7 +77,7 @@ func TestDevAdmListDevicesEmpty(t *testing.T) {
 
 func TestDevAdmListDevices(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevices", 0, 1, "").
+	db.On("GetDeviceAuths", 0, 1, "").
 		Return([]model.DeviceAuth{{}, {}, {}}, nil)
 
 	d := devadmForTest(db)
@@ -88,7 +88,7 @@ func TestDevAdmListDevices(t *testing.T) {
 
 func TestDevAdmListDevicesErr(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevices", 0, 1, "").
+	db.On("GetDeviceAuths", 0, 1, "").
 		Return([]model.DeviceAuth{}, errors.New("error"))
 
 	d := devadmForTest(db)
@@ -99,7 +99,7 @@ func TestDevAdmListDevicesErr(t *testing.T) {
 
 func TestDevAdmSubmitDevice(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
+	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
@@ -111,7 +111,7 @@ func TestDevAdmSubmitDevice(t *testing.T) {
 
 func TestDevAdmSubmitDeviceErr(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
+	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(errors.New("db connection failed"))
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
@@ -141,11 +141,11 @@ func makeGetDevice(id model.AuthID) func(id model.AuthID) (*model.DeviceAuth, er
 
 func TestDevAdmGetDevice(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevice", model.AuthID("foo")).
+	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo", DeviceId: "foo"}, nil)
-	db.On("GetDevice", model.AuthID("bar")).
+	db.On("GetDeviceAuth", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
-	db.On("GetDevice", model.AuthID("baz")).
+	db.On("GetDeviceAuth", model.AuthID("baz")).
 		Return(nil, errors.New("error"))
 
 	d := devadmForTest(db)
@@ -165,11 +165,11 @@ func TestDevAdmGetDevice(t *testing.T) {
 
 func TestDevAdmAcceptDevice(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevice", model.AuthID("foo")).
+	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo"}, nil)
-	db.On("GetDevice", model.AuthID("bar")).
+	db.On("GetDeviceAuth", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
-	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
+	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
@@ -208,7 +208,7 @@ func TestDevAdmDeleteDevice(t *testing.T) {
 		t.Run(fmt.Sprintf("test case: %s", name), func(t *testing.T) {
 
 			db := &mstore.DataStore{}
-			db.On("DeleteDevice",
+			db.On("DeleteDeviceAuth",
 				mock.AnythingOfType("model.AuthID"),
 			).Return(tc.datastoreError)
 			i := devadmForTest(db)
@@ -228,11 +228,11 @@ func TestDevAdmDeleteDevice(t *testing.T) {
 
 func TestDevAdmRejectDevice(t *testing.T) {
 	db := &mstore.DataStore{}
-	db.On("GetDevice", model.AuthID("foo")).
+	db.On("GetDeviceAuth", model.AuthID("foo")).
 		Return(&model.DeviceAuth{ID: "foo"}, nil)
-	db.On("GetDevice", model.AuthID("bar")).
+	db.On("GetDeviceAuth", model.AuthID("bar")).
 		Return(nil, store.ErrDevNotFound)
-	db.On("PutDevice", mock.AnythingOfType("*model.DeviceAuth")).
+	db.On("PutDeviceAuth", mock.AnythingOfType("*model.DeviceAuth")).
 		Return(nil)
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)

--- a/devadm/devadm_test.go
+++ b/devadm/devadm_test.go
@@ -71,7 +71,7 @@ func TestDevAdmListDevicesEmpty(t *testing.T) {
 
 	d := devadmForTest(db)
 
-	l, _ := d.ListDevices(0, 1, "")
+	l, _ := d.ListDeviceAuths(0, 1, "")
 	assert.Len(t, l, 0)
 }
 
@@ -82,7 +82,7 @@ func TestDevAdmListDevices(t *testing.T) {
 
 	d := devadmForTest(db)
 
-	l, _ := d.ListDevices(0, 1, "")
+	l, _ := d.ListDeviceAuths(0, 1, "")
 	assert.Len(t, l, 3)
 }
 
@@ -93,7 +93,7 @@ func TestDevAdmListDevicesErr(t *testing.T) {
 
 	d := devadmForTest(db)
 
-	_, err := d.ListDevices(0, 1, "")
+	_, err := d.ListDeviceAuths(0, 1, "")
 	assert.NotNil(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestDevAdmSubmitDevice(t *testing.T) {
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.SubmitDevice(model.DeviceAuth{})
+	err := d.SubmitDeviceAuth(model.DeviceAuth{})
 
 	assert.NoError(t, err)
 }
@@ -116,7 +116,7 @@ func TestDevAdmSubmitDeviceErr(t *testing.T) {
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.SubmitDevice(model.DeviceAuth{})
+	err := d.SubmitDeviceAuth(model.DeviceAuth{})
 
 	if assert.Error(t, err) {
 		assert.EqualError(t, err, "failed to put device: db connection failed")
@@ -150,15 +150,15 @@ func TestDevAdmGetDevice(t *testing.T) {
 
 	d := devadmForTest(db)
 
-	dev, err := d.GetDevice("foo")
+	dev, err := d.GetDeviceAuth("foo")
 	assert.NotNil(t, dev)
 	assert.NoError(t, err)
 
-	dev, err = d.GetDevice("bar")
+	dev, err = d.GetDeviceAuth("bar")
 	assert.Nil(t, dev)
 	assert.EqualError(t, err, store.ErrNotFound.Error())
 
-	dev, err = d.GetDevice("baz")
+	dev, err = d.GetDeviceAuth("baz")
 	assert.Nil(t, dev)
 	assert.Error(t, err)
 }
@@ -174,11 +174,11 @@ func TestDevAdmAcceptDevice(t *testing.T) {
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.AcceptDevice("foo")
+	err := d.AcceptDeviceAuth("foo")
 
 	assert.NoError(t, err)
 
-	err = d.AcceptDevice("bar")
+	err = d.AcceptDeviceAuth("bar")
 	assert.Error(t, err)
 	assert.EqualError(t, err, store.ErrNotFound.Error())
 }
@@ -213,7 +213,7 @@ func TestDevAdmDeleteDevice(t *testing.T) {
 			).Return(tc.datastoreError)
 			i := devadmForTest(db)
 
-			err := i.DeleteDevice("foo")
+			err := i.DeleteDeviceAuth("foo")
 
 			if tc.outError != nil {
 				if assert.Error(t, err) {
@@ -237,11 +237,11 @@ func TestDevAdmRejectDevice(t *testing.T) {
 
 	d := devadmWithClientForTest(db, http.StatusNoContent)
 
-	err := d.RejectDevice("foo")
+	err := d.RejectDeviceAuth("foo")
 
 	assert.NoError(t, err)
 
-	err = d.RejectDevice("bar")
+	err = d.RejectDeviceAuth("bar")
 	assert.Error(t, err)
 	assert.EqualError(t, err, store.ErrNotFound.Error())
 }

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -37,10 +37,6 @@ paths:
             Invalid parameters. See error message for details.
           schema:
             $ref: "#/definitions/Error"
-        404:
-         description: The device authentication data set was not found.
-         schema:
-            $ref: "#/definitions/Error"
         500:
           description: Internal server error.
           schema:
@@ -58,10 +54,6 @@ paths:
       responses:
         204:
           description: The device authentication data set was removed.
-        404:
-         description: The device authentication data set was not found.
-         schema:
-           $ref: "#/definitions/Error"
         500:
           description: Internal server error.
           schema:

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -48,18 +48,18 @@ paths:
   /devices/{id}:
     delete:
       summary: Remove device authentication data set
-      description: Removes all authentication set data
+      description: Removes all device authentication data set data.
       parameters:
         - name: id
           in: path
-          description: Authentication data set identifier
+          description: device authentication data set identifier
           required: true
           type: string
       responses:
         204:
           description: The device authentication data set was removed.
         404:
-         description: The authentication data set was not found.
+         description: The device authentication data set was not found.
          schema:
            $ref: "#/definitions/Error"
         500:

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -13,6 +13,38 @@ schemes:
   - http
 
 paths:
+  /devices:
+    delete:
+      summary: Delete device data sets
+      description: Removes device authentication data sets
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          type: string
+          format: Bearer [token]
+          description: Contains the JWT token issued by the User Administration and Authentication Service.
+        - name: device_id
+          in: query
+          description: Delete all auth sets owned by given device
+          required: true
+          type: string
+      responses:
+        204:
+          description: Authentication data sets removed.
+        400:
+          description: |
+            Invalid parameters. See error message for details.
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+         description: The device authentication data set was not found.
+         schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
   /devices/{id}:
     delete:
       summary: Remove device authentication data set

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -15,7 +15,7 @@ schemes:
 paths:
   /devices:
     get:
-      summary: List known device data sets
+      summary: List known device  data sets
       description: |
         Returns a paged collection of device authentication data sets registered
         for admission, and optionally filters by device admission status.
@@ -157,7 +157,7 @@ paths:
                 sn:  "SN1234567890"
               request_time: "2016-10-03T16:58:51.639Z"
         404:
-          description: The device was not found.
+          description: The device authentication data set was not found.
           schema:
             $ref: "#/definitions/Error"
         500:
@@ -166,8 +166,8 @@ paths:
             $ref: "#/definitions/Error"
   /devices/{id}/status:
     get:
-      summary: Check the admission status of a selected device
-      description: Returns the admission status of a particular device.
+      summary: Check the admission status of a selected device authentication data set
+      description: Returns the admission status of a particular device authentication data set.
       parameters:
         - name: Authorization
           in: header
@@ -190,7 +190,7 @@ paths:
             application/json:
               status: "accepted"
         404:
-          description: The device was not found.
+          description: The device authentication data set was not found.
           schema:
             $ref: "#/definitions/Error"
         500:
@@ -238,7 +238,7 @@ paths:
           schema:
             $ref: "#/definitions/Error"
         404:
-          description: The device was not found.
+          description: The device authentication data set was not found.
           schema:
             $ref: "#/definitions/Error"
         500:
@@ -308,7 +308,7 @@ definitions:
         description: Device public key
         type: string
       status:
-        description: Status of the admission process for the device
+        description: Status of the admission process for device authentication data set
         type: string
         enum:
           - pending
@@ -334,7 +334,7 @@ definitions:
         request_time: "2016-10-03T16:58:51.639Z"
 
   Status:
-    description: Admission status of the device.
+    description: Admission status of device authentication data set.
     type: object
     properties:
       status:

--- a/model/model_deviceauth.go
+++ b/model/model_deviceauth.go
@@ -20,8 +20,8 @@ import (
 type DeviceID string
 type AuthID string
 
-// wrapper for device attributes data
-type DeviceAttributes map[string]string
+// wrapper for device attributes data in authentication data set
+type DeviceAuthAttributes map[string]string
 
 const (
 	DevStatusAccepted = "accepted"
@@ -29,8 +29,8 @@ const (
 	DevStatusPending  = "pending"
 )
 
-// Device wrapper
-type Device struct {
+// Device authentication data set wrapper
+type DeviceAuth struct {
 	//system-generated authentication data set ID
 	ID AuthID `json:"id" bson:",omitempty"`
 
@@ -40,14 +40,14 @@ type Device struct {
 	//blob of encrypted identity attributes
 	DeviceIdentity string `json:"device_identity" bson:",omitempty"`
 
-	//device's public key
+	//public key passed in authentication request
 	Key string `json:"key" bson:",omitempty"`
 
 	//admission status('accepted', 'rejected', 'pending')
 	Status string `json:"status" bson:",omitempty"`
 
 	//decoded, human-readable identity attribute set
-	Attributes DeviceAttributes `json:"attributes" bson:",omitempty"`
+	Attributes DeviceAuthAttributes `json:"attributes" bson:",omitempty"`
 
 	//admission request reception time
 	RequestTime *time.Time `json:"request_time" bson:"request_time,omitempty"`

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -26,23 +26,23 @@ var (
 )
 
 type DataStore interface {
-	GetDevices(skip, limit int, status string) ([]model.DeviceAuth, error)
+	GetDeviceAuths(skip, limit int, status string) ([]model.DeviceAuth, error)
 
 	// find a device auth set with given `id`, returns the device auth set
 	// or nil, if auth set was not found, error is set to ErrDevNotFound
-	GetDevice(id model.AuthID) (*model.DeviceAuth, error)
+	GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, error)
 
 	// update or insert device auth set into data store, only non-empty
 	// fields will be stored/updated, for instance, to update a status of
 	// device auth set with ID "foo":
 	//
-	// ds.PutDevice(&DeviceAuth{
+	// ds.PutDeviceAuth(&DeviceAuth{
 	// 	ID: "foo",
 	//      DeviceId: "bar",
 	// 	Status: "accepted",
 	// })
-	PutDevice(dev *model.DeviceAuth) error
+	PutDeviceAuth(dev *model.DeviceAuth) error
 
 	// remove device auth set
-	DeleteDevice(id model.AuthID) error
+	DeleteDeviceAuth(id model.AuthID) error
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -26,23 +26,23 @@ var (
 )
 
 type DataStore interface {
-	GetDevices(skip, limit int, status string) ([]model.Device, error)
+	GetDevices(skip, limit int, status string) ([]model.DeviceAuth, error)
 
-	// find a device with given `id`, returns the device or nil,
-	// if device was not found, error is set to ErrDevNotFound
-	GetDevice(id model.AuthID) (*model.Device, error)
+	// find a device auth set with given `id`, returns the device auth set
+	// or nil, if auth set was not found, error is set to ErrDevNotFound
+	GetDevice(id model.AuthID) (*model.DeviceAuth, error)
 
-	// update or insert device into data store, only non-empty
-	// fields will be stored/updated, for instance, to update a
-	// status of device "foo":
+	// update or insert device auth set into data store, only non-empty
+	// fields will be stored/updated, for instance, to update a status of
+	// device auth set with ID "foo":
 	//
-	// ds.PutDevice(&Device{
+	// ds.PutDevice(&DeviceAuth{
 	// 	ID: "foo",
 	//      DeviceId: "bar",
 	// 	Status: "accepted",
 	// })
-	PutDevice(dev *model.Device) error
+	PutDevice(dev *model.DeviceAuth) error
 
-	// remove device
+	// remove device auth set
 	DeleteDevice(id model.AuthID) error
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -45,4 +45,7 @@ type DataStore interface {
 
 	// remove device auth set
 	DeleteDeviceAuth(id model.AuthID) error
+
+	// remove auth sets owned by device
+	DeleteDeviceAuthByDevice(id model.DeviceID) error
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	// device not found
-	ErrDevNotFound = errors.New("not found")
+	// object not found
+	ErrNotFound = errors.New("not found")
 )
 
 type DataStore interface {

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -22,8 +22,8 @@ type DataStore struct {
 	mock.Mock
 }
 
-// DeleteDevice provides a mock function with given fields: id
-func (_m *DataStore) DeleteDevice(id model.AuthID) error {
+// DeleteDeviceAuth provides a mock function with given fields: id
+func (_m *DataStore) DeleteDeviceAuth(id model.AuthID) error {
 	ret := _m.Called(id)
 
 	var r0 error
@@ -36,8 +36,8 @@ func (_m *DataStore) DeleteDevice(id model.AuthID) error {
 	return r0
 }
 
-// GetDevice provides a mock function with given fields: id
-func (_m *DataStore) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
+// GetDeviceAuth provides a mock function with given fields: id
+func (_m *DataStore) GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, error) {
 	ret := _m.Called(id)
 
 	var r0 *model.DeviceAuth
@@ -59,8 +59,8 @@ func (_m *DataStore) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 	return r0, r1
 }
 
-// GetDevices provides a mock function with given fields: skip, limit, status
-func (_m *DataStore) GetDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
+// GetDeviceAuths provides a mock function with given fields: skip, limit, status
+func (_m *DataStore) GetDeviceAuths(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 	ret := _m.Called(skip, limit, status)
 
 	var r0 []model.DeviceAuth
@@ -82,8 +82,8 @@ func (_m *DataStore) GetDevices(skip int, limit int, status string) ([]model.Dev
 	return r0, r1
 }
 
-// PutDevice provides a mock function with given fields: dev
-func (_m *DataStore) PutDevice(dev *model.DeviceAuth) error {
+// PutDeviceAuth provides a mock function with given fields: dev
+func (_m *DataStore) PutDeviceAuth(dev *model.DeviceAuth) error {
 	ret := _m.Called(dev)
 
 	var r0 error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -36,6 +36,20 @@ func (_m *DataStore) DeleteDeviceAuth(id model.AuthID) error {
 	return r0
 }
 
+// DeleteDeviceAuthByDevice provides a mock function with given fields: id
+func (_m *DataStore) DeleteDeviceAuthByDevice(id model.DeviceID) error {
+	ret := _m.Called(id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(model.DeviceID) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetDeviceAuth provides a mock function with given fields: id
 func (_m *DataStore) GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, error) {
 	ret := _m.Called(id)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -37,15 +37,15 @@ func (_m *DataStore) DeleteDevice(id model.AuthID) error {
 }
 
 // GetDevice provides a mock function with given fields: id
-func (_m *DataStore) GetDevice(id model.AuthID) (*model.Device, error) {
+func (_m *DataStore) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 	ret := _m.Called(id)
 
-	var r0 *model.Device
-	if rf, ok := ret.Get(0).(func(model.AuthID) *model.Device); ok {
+	var r0 *model.DeviceAuth
+	if rf, ok := ret.Get(0).(func(model.AuthID) *model.DeviceAuth); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Device)
+			r0 = ret.Get(0).(*model.DeviceAuth)
 		}
 	}
 
@@ -60,15 +60,15 @@ func (_m *DataStore) GetDevice(id model.AuthID) (*model.Device, error) {
 }
 
 // GetDevices provides a mock function with given fields: skip, limit, status
-func (_m *DataStore) GetDevices(skip int, limit int, status string) ([]model.Device, error) {
+func (_m *DataStore) GetDevices(skip int, limit int, status string) ([]model.DeviceAuth, error) {
 	ret := _m.Called(skip, limit, status)
 
-	var r0 []model.Device
-	if rf, ok := ret.Get(0).(func(int, int, string) []model.Device); ok {
+	var r0 []model.DeviceAuth
+	if rf, ok := ret.Get(0).(func(int, int, string) []model.DeviceAuth); ok {
 		r0 = rf(skip, limit, status)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]model.Device)
+			r0 = ret.Get(0).([]model.DeviceAuth)
 		}
 	}
 
@@ -83,11 +83,11 @@ func (_m *DataStore) GetDevices(skip int, limit int, status string) ([]model.Dev
 }
 
 // PutDevice provides a mock function with given fields: dev
-func (_m *DataStore) PutDevice(dev *model.Device) error {
+func (_m *DataStore) PutDevice(dev *model.DeviceAuth) error {
 	ret := _m.Called(dev)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.Device) error); ok {
+	if rf, ok := ret.Get(0).(func(*model.DeviceAuth) error); ok {
 		r0 = rf(dev)
 	} else {
 		r0 = ret.Error(0)

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -83,7 +83,7 @@ func (db *DataStoreMongo) GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, err
 
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, store.ErrDevNotFound
+			return nil, store.ErrNotFound
 		} else {
 			return nil, errors.Wrap(err, "failed to fetch device")
 		}
@@ -103,7 +103,7 @@ func (db *DataStoreMongo) DeleteDeviceAuth(id model.AuthID) error {
 	case nil:
 		return nil
 	case mgo.ErrNotFound:
-		return store.ErrDevNotFound
+		return store.ErrNotFound
 	default:
 		return errors.Wrap(err, "failed to delete device")
 	}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -51,7 +51,7 @@ func NewDataStoreMongo(host string) (*DataStoreMongo, error) {
 	return NewDataStoreMongoWithSession(s), nil
 }
 
-func (db *DataStoreMongo) GetDevices(skip, limit int, status string) ([]model.DeviceAuth, error) {
+func (db *DataStoreMongo) GetDeviceAuths(skip, limit int, status string) ([]model.DeviceAuth, error) {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)
@@ -71,7 +71,7 @@ func (db *DataStoreMongo) GetDevices(skip, limit int, status string) ([]model.De
 	return res, nil
 }
 
-func (db *DataStoreMongo) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
+func (db *DataStoreMongo) GetDeviceAuth(id model.AuthID) (*model.DeviceAuth, error) {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)
@@ -92,7 +92,7 @@ func (db *DataStoreMongo) GetDevice(id model.AuthID) (*model.DeviceAuth, error) 
 	return &res, nil
 }
 
-func (db *DataStoreMongo) DeleteDevice(id model.AuthID) error {
+func (db *DataStoreMongo) DeleteDeviceAuth(id model.AuthID) error {
 	s := db.session.Copy()
 	defer s.Close()
 
@@ -109,9 +109,9 @@ func (db *DataStoreMongo) DeleteDevice(id model.AuthID) error {
 	}
 }
 
-// produce a Device wrapper suitable for passing in an Upsert() as
+// produce a DeviceAuth wrapper suitable for passing in an Upsert() as
 // '$set' fields
-func genDeviceUpdate(dev *model.DeviceAuth) *model.DeviceAuth {
+func genDeviceAuthUpdate(dev *model.DeviceAuth) *model.DeviceAuth {
 	updev := model.DeviceAuth{}
 
 	if dev.DeviceId != "" {
@@ -143,7 +143,7 @@ func genDeviceUpdate(dev *model.DeviceAuth) *model.DeviceAuth {
 }
 
 //
-func (db *DataStoreMongo) PutDevice(dev *model.DeviceAuth) error {
+func (db *DataStoreMongo) PutDeviceAuth(dev *model.DeviceAuth) error {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)
@@ -151,7 +151,7 @@ func (db *DataStoreMongo) PutDevice(dev *model.DeviceAuth) error {
 	filter := bson.M{"id": dev.ID}
 
 	// use $set operator so that fields values are replaced
-	data := bson.M{"$set": genDeviceUpdate(dev)}
+	data := bson.M{"$set": genDeviceAuthUpdate(dev)}
 
 	// does insert or update
 	_, err := c.Upsert(filter, data)

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -109,6 +109,23 @@ func (db *DataStoreMongo) DeleteDeviceAuth(id model.AuthID) error {
 	}
 }
 
+func (db *DataStoreMongo) DeleteDeviceAuthByDevice(id model.DeviceID) error {
+	s := db.session.Copy()
+	defer s.Close()
+
+	filter := model.DeviceAuth{DeviceId: id}
+	ci, err := s.DB(DbName).C(DbDevicesColl).RemoveAll(filter)
+
+	switch {
+	case err != nil:
+		return nil
+	case ci != nil && ci.Removed == 0:
+		return store.ErrNotFound
+	default:
+		return errors.Wrap(err, "failed to delete device")
+	}
+}
+
 // produce a DeviceAuth wrapper suitable for passing in an Upsert() as
 // '$set' fields
 func genDeviceAuthUpdate(dev *model.DeviceAuth) *model.DeviceAuth {

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -51,11 +51,11 @@ func NewDataStoreMongo(host string) (*DataStoreMongo, error) {
 	return NewDataStoreMongoWithSession(s), nil
 }
 
-func (db *DataStoreMongo) GetDevices(skip, limit int, status string) ([]model.Device, error) {
+func (db *DataStoreMongo) GetDevices(skip, limit int, status string) ([]model.DeviceAuth, error) {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)
-	res := []model.Device{}
+	res := []model.DeviceAuth{}
 
 	var filter bson.M
 	if status != "" {
@@ -71,13 +71,13 @@ func (db *DataStoreMongo) GetDevices(skip, limit int, status string) ([]model.De
 	return res, nil
 }
 
-func (db *DataStoreMongo) GetDevice(id model.AuthID) (*model.Device, error) {
+func (db *DataStoreMongo) GetDevice(id model.AuthID) (*model.DeviceAuth, error) {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)
 
 	filter := bson.M{"id": id}
-	res := model.Device{}
+	res := model.DeviceAuth{}
 
 	err := c.Find(filter).One(&res)
 
@@ -111,8 +111,8 @@ func (db *DataStoreMongo) DeleteDevice(id model.AuthID) error {
 
 // produce a Device wrapper suitable for passing in an Upsert() as
 // '$set' fields
-func genDeviceUpdate(dev *model.Device) *model.Device {
-	updev := model.Device{}
+func genDeviceUpdate(dev *model.DeviceAuth) *model.DeviceAuth {
+	updev := model.DeviceAuth{}
 
 	if dev.DeviceId != "" {
 		updev.DeviceId = dev.DeviceId
@@ -143,7 +143,7 @@ func genDeviceUpdate(dev *model.Device) *model.Device {
 }
 
 //
-func (db *DataStoreMongo) PutDevice(dev *model.Device) error {
+func (db *DataStoreMongo) PutDevice(dev *model.DeviceAuth) error {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(DbName).C(DbDevicesColl)

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -103,7 +103,7 @@ func TestMongoGetDevices(t *testing.T) {
 
 	var err error
 
-	_, err = d.GetDevices(0, 5, "")
+	_, err = d.GetDeviceAuths(0, 5, "")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -177,7 +177,7 @@ func TestMongoGetDevices(t *testing.T) {
 		assert.NoError(t, err, "failed to parse expected devs %s", tc.expected)
 
 		//test
-		devs, err := d.GetDevices(tc.skip, tc.limit, tc.status)
+		devs, err := d.GetDeviceAuths(tc.skip, tc.limit, tc.status)
 		assert.NoError(t, err, "failed to get devices")
 
 		if !reflect.DeepEqual(expected, devs) {
@@ -203,7 +203,7 @@ func TestMongoGetDevice(t *testing.T) {
 	defer d.session.Close()
 	var err error
 
-	_, err = d.GetDevice("")
+	_, err = d.GetDeviceAuth("")
 	assert.Error(t, err, "expected error")
 
 	// populate DB
@@ -218,7 +218,7 @@ func TestMongoGetDevice(t *testing.T) {
 	for _, dev := range expected {
 		// we expect to find a device that was present in the
 		// input set
-		dbdev, err := d.GetDevice(dev.ID)
+		dbdev, err := d.GetDeviceAuth(dev.ID)
 		assert.NoError(t, err, "expected no error")
 		assert.NotNil(t, dbdev, "expected to device of ID %s to be found",
 			dev.ID)
@@ -227,7 +227,7 @@ func TestMongoGetDevice(t *testing.T) {
 			dbdev, dev)
 
 		// modify device ID by appending bogus string to it
-		dbdev, err = d.GetDevice(dev.ID + "-foobar")
+		dbdev, err = d.GetDeviceAuth(dev.ID + "-foobar")
 		assert.Nil(t, dbdev, "expected nil got %+v", dbdev)
 		assert.EqualError(t, err, store.ErrDevNotFound.Error(), "expected error")
 	}
@@ -243,7 +243,7 @@ func TestMongoPutDevice(t *testing.T) {
 	defer d.session.Close()
 	var err error
 
-	_, err = d.GetDevice("")
+	_, err = d.GetDeviceAuth("")
 	assert.Error(t, err, "expected error")
 
 	// populate DB
@@ -256,7 +256,7 @@ func TestMongoPutDevice(t *testing.T) {
 
 	// insert all devices to DB
 	for _, dev := range devs {
-		err := d.PutDevice(&dev)
+		err := d.PutDeviceAuth(&dev)
 		assert.NoError(t, err, "expected no error inserting to data store")
 	}
 
@@ -264,7 +264,7 @@ func TestMongoPutDevice(t *testing.T) {
 	for _, dev := range devs {
 		// we expect to find a device that was present in the
 		// input set
-		dbdev, err := d.GetDevice(dev.ID)
+		dbdev, err := d.GetDeviceAuth(dev.ID)
 		assert.NoError(t, err, "expected no error")
 		assert.NotNil(t, dbdev, "expected to device of ID %s to be found",
 			dev.ID)
@@ -281,7 +281,7 @@ func TestMongoPutDevice(t *testing.T) {
 		}
 
 		// update device key
-		err = d.PutDevice(&ndev)
+		err = d.PutDeviceAuth(&ndev)
 		assert.NoError(t, err, "expected no error updating devices in DB")
 	}
 
@@ -289,7 +289,7 @@ func TestMongoPutDevice(t *testing.T) {
 	for _, dev := range devs {
 		// we expect to find a device that was present in the
 		// input set
-		dbdev, err := d.GetDevice(dev.ID)
+		dbdev, err := d.GetDeviceAuth(dev.ID)
 		assert.NoError(t, err, "expected no error")
 		assert.NotNil(t, dbdev, "expected to device of ID %s to be found",
 			dev.ID)
@@ -313,7 +313,7 @@ func TestMongoPutDeviceTime(t *testing.T) {
 	defer d.session.Close()
 	var err error
 
-	dev, err := d.GetDevice("foobar")
+	dev, err := d.GetDeviceAuth("foobar")
 	assert.Nil(t, dev)
 	assert.EqualError(t, err, store.ErrDevNotFound.Error())
 
@@ -326,10 +326,10 @@ func TestMongoPutDeviceTime(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	err = d.PutDevice(&expdev)
+	err = d.PutDeviceAuth(&expdev)
 	assert.NoError(t, err)
 
-	dev, err = d.GetDevice("foobar")
+	dev, err = d.GetDeviceAuth("foobar")
 	assert.NotNil(t, dev)
 	assert.NoError(t, err)
 
@@ -478,7 +478,7 @@ func TestMongoDeleteDevice(t *testing.T) {
 
 		store := NewDataStoreMongoWithSession(session)
 
-		err := store.DeleteDevice(tc.id)
+		err := store.DeleteDeviceAuth(tc.id)
 		if tc.err != nil {
 			assert.EqualError(t, err, tc.err.Error())
 		} else {

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -229,7 +229,7 @@ func TestMongoGetDevice(t *testing.T) {
 		// modify device ID by appending bogus string to it
 		dbdev, err = d.GetDeviceAuth(dev.ID + "-foobar")
 		assert.Nil(t, dbdev, "expected nil got %+v", dbdev)
-		assert.EqualError(t, err, store.ErrDevNotFound.Error(), "expected error")
+		assert.EqualError(t, err, store.ErrNotFound.Error(), "expected error")
 	}
 
 }
@@ -315,7 +315,7 @@ func TestMongoPutDeviceTime(t *testing.T) {
 
 	dev, err := d.GetDeviceAuth("foobar")
 	assert.Nil(t, dev)
-	assert.EqualError(t, err, store.ErrDevNotFound.Error())
+	assert.EqualError(t, err, store.ErrNotFound.Error())
 
 	now := time.Now()
 	expdev := model.DeviceAuth{
@@ -462,7 +462,7 @@ func TestMongoDeleteDevice(t *testing.T) {
 					Status:         "pending",
 				},
 			},
-			err: store.ErrDevNotFound,
+			err: store.ErrNotFound,
 		},
 	}
 

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -76,13 +76,13 @@ func wipe(db *DataStoreMongo) error {
 	return nil
 }
 
-func parseDevs(dataset string) ([]model.Device, error) {
+func parseDevs(dataset string) ([]model.DeviceAuth, error) {
 	f, err := os.Open(filepath.Join(testDataFolder, dataset))
 	if err != nil {
 		return nil, err
 	}
 
-	var devs []model.Device
+	var devs []model.DeviceAuth
 
 	j := json.NewDecoder(f)
 	if err = j.Decode(&devs); err != nil {
@@ -275,7 +275,7 @@ func TestMongoPutDevice(t *testing.T) {
 			dbdev, dev)
 
 		// modify device staus
-		ndev := model.Device{
+		ndev := model.DeviceAuth{
 			Status: "accepted",
 			ID:     dbdev.ID,
 		}
@@ -318,11 +318,11 @@ func TestMongoPutDeviceTime(t *testing.T) {
 	assert.EqualError(t, err, store.ErrDevNotFound.Error())
 
 	now := time.Now()
-	expdev := model.Device{
+	expdev := model.DeviceAuth{
 		ID:          "foobar",
 		DeviceId:    "bar",
 		RequestTime: &now,
-		Attributes: model.DeviceAttributes{
+		Attributes: model.DeviceAuthAttributes{
 			"foo": "bar",
 		},
 	}
@@ -396,15 +396,15 @@ func TestMongoDeleteDevice(t *testing.T) {
 		t.Skip("skipping TestMongoDeleteDevice in short mode.")
 	}
 
-	inDevs := []model.Device{
-		model.Device{
+	inDevs := []model.DeviceAuth{
+		model.DeviceAuth{
 			ID:             "0001",
 			DeviceId:       "0001",
 			DeviceIdentity: "0001-id",
 			Key:            "0001-key",
 			Status:         "pending",
 		},
-		model.Device{
+		model.DeviceAuth{
 			ID:             "0002",
 			DeviceId:       "0002",
 			DeviceIdentity: "0002-id",
@@ -415,13 +415,13 @@ func TestMongoDeleteDevice(t *testing.T) {
 
 	testCases := map[string]struct {
 		id  model.AuthID
-		out []model.Device
+		out []model.DeviceAuth
 		err error
 	}{
 		"exists 1": {
 			id: "0001",
-			out: []model.Device{
-				model.Device{
+			out: []model.DeviceAuth{
+				model.DeviceAuth{
 					ID:             "0002",
 					DeviceId:       "0002",
 					DeviceIdentity: "0002-id",
@@ -433,8 +433,8 @@ func TestMongoDeleteDevice(t *testing.T) {
 		},
 		"exists 2": {
 			id: "0002",
-			out: []model.Device{
-				model.Device{
+			out: []model.DeviceAuth{
+				model.DeviceAuth{
 					ID:             "0001",
 					DeviceId:       "0001",
 					DeviceIdentity: "0001-id",
@@ -446,15 +446,15 @@ func TestMongoDeleteDevice(t *testing.T) {
 		},
 		"doesn't exist": {
 			id: "foo",
-			out: []model.Device{
-				model.Device{
+			out: []model.DeviceAuth{
+				model.DeviceAuth{
 					ID:             "0001",
 					DeviceId:       "0001",
 					DeviceIdentity: "0001-id",
 					Key:            "0001-key",
 					Status:         "pending",
 				},
-				model.Device{
+				model.DeviceAuth{
 					ID:             "0002",
 					DeviceId:       "0002",
 					DeviceIdentity: "0002-id",
@@ -485,7 +485,7 @@ func TestMongoDeleteDevice(t *testing.T) {
 			assert.NoError(t, err, "failed to delete device")
 		}
 
-		var outDevs []model.Device
+		var outDevs []model.DeviceAuth
 		err = session.DB(DbName).C(DbDevicesColl).Find(nil).All(&outDevs)
 		assert.NoError(t, err, "failed to verify devices")
 

--- a/store/mongo/migration_1_0_0_test.go
+++ b/store/mongo/migration_1_0_0_test.go
@@ -44,10 +44,10 @@ func randDevStatus() string {
 
 type migration_1_0_0_TestData struct {
 	// devices by device index
-	devices map[int]*model.Device
+	devices map[int]*model.DeviceAuth
 }
 
-func (m *migration_1_0_0_TestData) GetDev(idx int) *model.Device {
+func (m *migration_1_0_0_TestData) GetDev(idx int) *model.DeviceAuth {
 	return m.devices[idx]
 }
 
@@ -55,7 +55,7 @@ func (m *migration_1_0_0_TestData) GetDev(idx int) *model.Device {
 func populateDevices(t *testing.T, s *mgo.Session, count int) migration_1_0_0_TestData {
 
 	td := migration_1_0_0_TestData{
-		devices: map[int]*model.Device{},
+		devices: map[int]*model.DeviceAuth{},
 	}
 
 	now := time.Now()
@@ -64,13 +64,13 @@ func populateDevices(t *testing.T, s *mgo.Session, count int) migration_1_0_0_Te
 
 		tm := randTime(now)
 		// devices in pre 1.1.0 version had DeviceId unset
-		dev := model.Device{
+		dev := model.DeviceAuth{
 			ID:             model.AuthID(devid),
 			Key:            fmt.Sprintf("pubkey-0.1.0-%d", i),
 			DeviceIdentity: fmt.Sprintf("id-data-0.1.0-%d", i),
 			Status:         randDevStatus(),
 			RequestTime:    &tm,
-			Attributes: model.DeviceAttributes{
+			Attributes: model.DeviceAuthAttributes{
 				"foo": fmt.Sprintf("attr-0.1.0-%d", i),
 			},
 		}
@@ -102,7 +102,7 @@ func TestMigration_1_0_0(t *testing.T) {
 	assert.Equal(t, devCount, cnt)
 
 	// trying to add a device auth set with same ID should raise conflict
-	err = s.DB(DbName).C(DbDevicesColl).Insert(&model.Device{
+	err = s.DB(DbName).C(DbDevicesColl).Insert(&model.DeviceAuth{
 		ID: data.GetDev(10).ID,
 	})
 	assert.True(t, mgo.IsDup(err))

--- a/store/mongo/migration_1_0_0_test.go
+++ b/store/mongo/migration_1_0_0_test.go
@@ -109,7 +109,7 @@ func TestMigration_1_0_0(t *testing.T) {
 
 	// verify that DeviceId was set for every device
 	for _, dev := range data.devices {
-		dbdev, err := db.GetDevice(dev.ID)
+		dbdev, err := db.GetDeviceAuth(dev.ID)
 		assert.NoError(t, err)
 
 		// DeviceId should have been set to the value of ID

--- a/store/mongo/migration_1_1_0.go
+++ b/store/mongo/migration_1_1_0.go
@@ -31,7 +31,7 @@ func (m *migration_1_1_0) Up(from migrate.Version) error {
 
 	iter := s.DB(DbName).C(DbDevicesColl).Find(nil).Iter()
 
-	var olddev model.Device
+	var olddev model.DeviceAuth
 
 	for iter.Next(&olddev) {
 		newdev := olddev


### PR DESCRIPTION
Here it comes. The series adds support for`DELETE /devices?device_id=<did>`. `device_id` is a *required* parameter.

Aside from DELETE, there's also some cleanups, like:
* updated wording in API spec
* renamed `Device` to `DeviceAuth`
* changed method names to reflect that they operate on `DeviceAuth`

@mendersoftware/rndity @maciejmrowiec 