### PR TITLE
acceptance tests: introduce multitenancy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ script:
         CGO_ENABLED=0 go test -c -o deviceadm -coverpkg $(go list ./... | grep -v vendor | grep -v mocks | grep -v test | tr  '\n' ,);
         sudo docker build -f Dockerfile.acceptance-testing -t mendersoftware/deviceadm:prtest .;
         ./tests/build-acceptance ./tests ./docs/management_api.yml ./docs/internal_api.yml;
-        TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration_new ./tests/docker-compose.yml;
+        TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration_new ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration_new ./tests/docker-compose-acceptance-mt.yml;
       fi
 
     - if [ "$JOB_TYPE" = compile_and_basic_tests ] ; then

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,7 +3,9 @@ FROM ubuntu:16.04
 RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pip \
     python3-pytest python3-crypto python3-twisted python3-requests python3-yaml
-RUN pip3 install --quiet bravado
+RUN pip3 install --quiet bravado flask
+
+EXPOSE 5000
 
 RUN mkdir -p /testing
 ENTRYPOINT ["bash", "/testing/run.sh"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,6 +42,24 @@ def sign_data(data, privateKey):
     sign = signer.sign(digest)
     return b64encode(sign)
 
+def make_id_jwt(sub, tenant=None):
+    """
+        Prepare an almost-valid JWT token, suitable for consumption by our identity middleware (needs sub and optionally mender.tenant claims).
+
+        The token contains valid base64-encoded payload, but the header/signature are bogus.
+        This is enough for the identity middleware to interpret the identity
+        and select the correct db; note that there is no gateway in the test setup, so the signature
+        is never verified. It's also enough to provide a tenant_token for deviceauth.
+
+        If 'tenant' is specified, the 'mender.tenant' claim is added.
+    """
+    payload = {"sub": sub}
+    if tenant is not None:
+        payload["mender.tenant"] = tenant
+    payload = json.dumps(payload)
+    payloadb64 = b64encode(payload.encode("utf-8"))
+    return "bogus_header." + payloadb64.decode() + ".bogus_sign"
+
 
 # Create devices using the Device Authentication microservice
 @pytest.fixture(scope="class")

--- a/tests/docker-compose-acceptance-mt.yml
+++ b/tests/docker-compose-acceptance-mt.yml
@@ -10,10 +10,16 @@ services:
             - mender-device-adm
             - mender-device-auth
             - mender-inventory
-        command: -k "not Multitenant"
+        # run multi tenant tests only
+        command: -k Multitenant
     mender-device-adm:
             # built/tagged locally and only used for testing
             image: mendersoftware/deviceadm:prtest
             volumes:
                 - "${TESTS_DIR}:/testing"
 
+    mender-device-auth:
+        environment:
+            # acceptance container will be running fake tenantadm service,
+            # direct deviceauth there
+            DEVICEAUTH_TENANTADM_ADDR: "http://acceptance:5000"

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -16,4 +16,3 @@ services:
             image: mendersoftware/deviceadm:prtest
             volumes:
                 - "${TESTS_DIR}:/testing"
-

--- a/tests/tenantadm.py
+++ b/tests/tenantadm.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+from multiprocessing import Process
+from flask import Flask
+import logging
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
+app = Flask(__name__)
+server = None
+
+@app.route("/api/internal/v1/tenantadm/tenants/verify", methods=["POST"])
+def verify():
+    return "", 200
+
+class fake_tenantadm:
+    def __enter__(self):
+        self.server = Process(target=app.run, kwargs={'host': '0.0.0.0'})
+        self.server.daemon=True
+        self.server.start()
+    def __exit__(self, type, value, traceback):
+        self.server.terminate()
+        self.server.join()

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -2,6 +2,9 @@ import logging
 import os
 
 import pytest
+import json
+import base64
+import common
 from bravado.swagger_model import load_file
 from bravado.client import SwaggerClient, RequestsClient
 from requests.utils import parse_header_links
@@ -52,8 +55,8 @@ class ManagementClient(SwaggerApiClient):
 
     spec_option = 'management_spec'
 
-    #user auth - dummy, just to make swagger client happy
-    uauth = {"headers": {"Authorization": "Bearer foobarbaz"}}
+    # default user auth - single user, single tenant
+    uauth = {"Authorization": "Bearer foobarbaz"}
 
     def setup(self):
         self.setup_swagger()
@@ -66,6 +69,14 @@ class ManagementClient(SwaggerApiClient):
                 return r + self.get_all_devices(page=page)
         else:
             return r
+
+    def make_user_auth(self, user_id, tenant_id=None):
+        """
+            Prepare an almost-valid JWT auth header, suitable for consumption by deviceadm.
+        """
+        jwt = common.make_id_jwt(user_id, tenant_id)
+        return {"Authorization": "Bearer " + jwt}
+
 
 class ManagementClientSimple(ManagementClient):
     log = logging.getLogger('client.ManagementClientSimple')

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -47,8 +47,12 @@ class InternalClient(SwaggerApiClient):
     def setup(self):
         self.setup_swagger()
 
-    def delete_device(self, id):
-        return requests.delete(self.make_api_url('/devices?device_id={}'.format(id)))
+    def delete_device(self, id, auth=None):
+        return requests.delete(self.make_api_url('/devices?device_id={}'.format(id)), headers=auth)
+
+    def make_id_auth(self, user, tenant):
+        jwt = common.make_id_jwt(user, tenant)
+        return {"Authorization" : "Bearer " + jwt}
 
 class ManagementClient(SwaggerApiClient):
     log = logging.getLogger('client.ManagementClient')
@@ -68,7 +72,7 @@ class ManagementClient(SwaggerApiClient):
         for i in parse_header_links(h.headers["link"]):
             if i["rel"] == "next":
                 page = int(dict(urlparse.parse_qs(urlparse.urlsplit(i["url"]).query))["page"][0])
-                return r + self.get_all_devices(page=page)
+                return r + self.get_all_devices(page=page, auth=auth)
         else:
             return r
 

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -61,8 +61,10 @@ class ManagementClient(SwaggerApiClient):
     def setup(self):
         self.setup_swagger()
 
-    def get_all_devices(self, page=1):
-        r, h = self.client.devices.get_devices(page=page, _request_options=self.uauth).result()
+    def get_all_devices(self, page=1, auth=None):
+        if auth is None:
+            auth=self.uauth
+        r, h = self.client.devices.get_devices(page=page, _request_options={"headers": auth}).result()
         for i in parse_header_links(h.headers["link"]):
             if i["rel"] == "next":
                 page = int(dict(urlparse.parse_qs(urlparse.urlsplit(i["url"]).query))["page"][0])

--- a/tests/tests/test_delete_device.py
+++ b/tests/tests/test_delete_device.py
@@ -1,13 +1,13 @@
 from client import ManagementClientSimple, InternalClient
-from common import create_devices
+from common import create_devices, create_devices_mt
 import pytest
 
 @pytest.mark.usefixtures("create_devices")
 class TestDeleteDevice(InternalClient):
-    def test_delete(self):
+    def do_test_delete(self, auth=None):
         #first pull existing device sets to get some existing device_id
         mc = ManagementClientSimple()
-        devs = mc.get_all_devices()
+        devs = mc.get_all_devices(auth=auth)
         num_devs_base = len(devs)
 
         assert num_devs_base > 0
@@ -15,10 +15,10 @@ class TestDeleteDevice(InternalClient):
         existing = devs[0]
 
         #delete existing device set, verify it's gone
-        rsp = self.delete_device(existing.device_id)
+        rsp = self.delete_device(existing.device_id, auth)
         assert rsp.status_code == 204
 
-        devs = mc.get_all_devices()
+        devs = mc.get_all_devices(auth=auth)
         num_devs = len(devs)
         assert num_devs == num_devs_base - 1
 
@@ -29,6 +29,15 @@ class TestDeleteDevice(InternalClient):
         rsp = self.delete_device('foobar')
         assert rsp.status_code == 204
 
-        devs = mc.get_all_devices()
+        devs = mc.get_all_devices(auth=auth)
         assert len(devs) == num_devs
 
+    def test_delete(self):
+        self.do_test_delete()
+
+@pytest.mark.usefixtures("create_devices_mt")
+class TestDeleteDeviceMultitenant(TestDeleteDevice):
+    @pytest.mark.parametrize("tenant_id", ["tenant1", "tenant2"])
+    def test_delete(self, tenant_id):
+        auth = self.make_id_auth("foo", tenant_id)
+        self.do_test_delete(auth=auth)

--- a/tests/tests/test_get_devices.py
+++ b/tests/tests/test_get_devices.py
@@ -27,7 +27,7 @@ class TestPrebootstrap(ManagementClient):
             Test getting a specific device results in 404
         """
         try:
-            self.client.devices.get_devices_id(id="0c396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options=self.uauth).result()
+            self.client.devices.get_devices_id(id="0c396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options={"headers": auth}).result()
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 404
         else:

--- a/tests/tests/test_get_devices.py
+++ b/tests/tests/test_get_devices.py
@@ -1,28 +1,25 @@
 from client import ManagementClient
 import bravado
-from common import create_devices
+from common import create_devices, create_devices_mt
 import pytest
 
 @pytest.mark.usefixtures("create_devices")
 class TestPrebootstrap(ManagementClient):
-
-    def test_get_all_devices(self, expected_total=pytest.config.getoption("devices")):
+    def do_test_get_all_devices(self, auth, expected_total=pytest.config.getoption("devices")):
         """
             Test all devices appear after being bootstrapped
         """
-        assert len(self.get_all_devices()) >= int(expected_total)
+        assert len(self.get_all_devices(auth=auth)) >= int(expected_total)
 
-
-    def test_get_devices(self):
+    def do_test_get_devices(self, auth):
         """
             Test getting a specific device
         """
-        devices = self.get_all_devices()
+        devices = self.get_all_devices(auth=auth)
         first = devices[0]
         assert first.status == "pending"
 
-
-    def test_get_non_existant_device(self):
+    def do_test_get_non_existant_device(self, auth):
         """
             Test getting a specific device results in 404
         """
@@ -33,3 +30,30 @@ class TestPrebootstrap(ManagementClient):
         else:
             pytest.fail("Error code 404 not returned")
 
+    def test_get_all_devices(self):
+        self.do_test_get_all_devices(auth=self.uauth)
+
+    def test_get_devices(self):
+        self.do_test_get_devices(auth=self.uauth)
+
+    def test_get_non_existant_device(self):
+        self.do_test_get_non_existant_device(auth=self.uauth)
+
+
+@pytest.mark.usefixtures("create_devices_mt")
+class TestPrebootstrapMultitenant(TestPrebootstrap):
+
+    @pytest.mark.parametrize("tenant_id", ["tenant1", "tenant2"])
+    def test_get_all_devices(self, tenant_id):
+        auth = self.make_user_auth("user", tenant_id)
+        self.do_test_get_all_devices(auth=auth)
+
+    @pytest.mark.parametrize("tenant_id", ["tenant1", "tenant2"])
+    def test_get_devices(self, tenant_id):
+        auth = self.make_user_auth("user", tenant_id)
+        self.do_test_get_devices(auth=auth)
+
+    @pytest.mark.parametrize("tenant_id", ["tenant1", "tenant2"])
+    def test_get_non_existant_device(self, tenant_id):
+        auth = self.make_user_auth("user", tenant_id)
+        self.do_test_get_non_existant_device(auth=auth)

--- a/tests/tests/test_no_devices.py
+++ b/tests/tests/test_no_devices.py
@@ -12,7 +12,7 @@ class TestPrebootstrap(ManagementClient):
             Test getting a device when non exist results in 404
         """
         try:
-            self.client.devices.get_devices_id(id="0c396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options=self.uauth).result()
+            self.client.devices.get_devices_id(id="0c396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options={"headers": self.uauth}).result()
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 404
         else:
@@ -24,7 +24,7 @@ class TestPrebootstrap(ManagementClient):
             Test getting a device status when non exist results in 404
         """
         try:
-            self.client.devices.get_devices_id_status(id="ac396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options=self.uauth).result()
+            self.client.devices.get_devices_id_status(id="ac396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", _request_options={"headers": self.uauth}).result()
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 404
         else:
@@ -38,7 +38,7 @@ class TestPrebootstrap(ManagementClient):
         try:
             Status = self.client.get_model('Status')
             s = Status(status="accepted")
-            self.client.devices.put_devices_id_status(id="ac396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", status=s, _request_options=self.uauth).result()
+            self.client.devices.put_devices_id_status(id="ac396e0032f2b4367d6abe709c889ced728df1f97eb0c368a41465aa24a89454", status=s, _request_options={"headers": self.uauth}).result()
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 404
         else:

--- a/tests/tests/test_put_devices.py
+++ b/tests/tests/test_put_devices.py
@@ -1,6 +1,7 @@
 from client import ManagementClient
 import bravado
-from common import create_devices
+from common import create_devices, create_devices_mt
+from tenantadm import fake_tenantadm
 import pytest
 
 @pytest.mark.usefixtures("create_devices")
@@ -25,41 +26,54 @@ class TestPrebootstrap(ManagementClient):
 
         assert self.client.devices.get_devices_id(id=device_id, _request_options={"headers": auth}).result()[0].status == expected_final
 
-
-    def test_change_status(self):
-        """
-            Test every possible status transition works, invalid and non-specified transitions fail
-        """
-        r, h = self.client.devices.get_devices(_request_options=self.uauth).result()
+    def do_test_change_status(self, auth):
+        r, h = self.client.devices.get_devices(_request_options={"headers": auth}).result()
 
         firstDevice = r[0]
         secondDevice = r[1]
         thirdDevice = r[2]
 
         # go from pending => accepted
-        self.change_status(firstDevice.id, expected_initial="pending", expected_final="accepted")
+        self.change_status(firstDevice.id, expected_initial="pending", expected_final="accepted", auth=auth)
 
         # go from pending => rejected
-        self.change_status(secondDevice.id, expected_initial="pending", expected_final="rejected")
+        self.change_status(secondDevice.id, expected_initial="pending", expected_final="rejected", auth=auth)
 
         # go from rejected => accepted
-        self.change_status(secondDevice.id, expected_initial="rejected", expected_final="accepted")
+        self.change_status(secondDevice.id, expected_initial="rejected", expected_final="accepted", auth=auth)
 
         # go from accepted => rejected
-        self.change_status(firstDevice.id, expected_initial="accepted", expected_final="rejected")
+        self.change_status(firstDevice.id, expected_initial="accepted", expected_final="rejected", auth=auth)
 
         # go from pending => rejected => accepted
-        self.change_status(thirdDevice.id, expected_initial="pending", expected_final="rejected")
-        self.change_status(thirdDevice.id, expected_initial="rejected", expected_final="accepted")
+        self.change_status(thirdDevice.id, expected_initial="pending", expected_final="rejected", auth=auth)
+        self.change_status(thirdDevice.id, expected_initial="rejected", expected_final="accepted", auth=auth)
 
         # go from rejected => pending
-        self.change_status(firstDevice.id, expected_initial="rejected", expected_final="pending", expected_error_code=400)
+        self.change_status(firstDevice.id, expected_initial="rejected", expected_final="pending", expected_error_code=400, auth=auth)
 
         # go from accepted => pending
-        self.change_status(secondDevice.id, expected_initial="accepted", expected_final="pending", expected_error_code=400)
+        self.change_status(secondDevice.id, expected_initial="accepted", expected_final="pending", expected_error_code=400, auth=auth)
 
         # go from accepted => blah
-        self.change_status(secondDevice.id, expected_initial="accepted", expected_final="blah", expected_error_code=400)
+        self.change_status(secondDevice.id, expected_initial="accepted", expected_final="blah", expected_error_code=400, auth=auth)
 
         # device not found
-        self.change_status(secondDevice.id+'1', expected_initial="accepted", expected_final="pending", expected_error_code=404)
+        self.change_status(secondDevice.id+'1', expected_initial="accepted", expected_final="pending", expected_error_code=404, auth=auth)
+
+    def test_change_status(self):
+        """
+            Test every possible status transition works, invalid and non-specified transitions fail
+        """
+        self.do_test_change_status(auth=self.uauth)
+
+@pytest.mark.usefixtures("create_devices_mt")
+class TestPrebootstrapMultitenant(TestPrebootstrap):
+    @pytest.mark.parametrize("tenant_id", ["tenant1", "tenant2"])
+    def test_change_status(self, tenant_id):
+        """
+            Test every possible status transition works, invalid and non-specified transitions fail
+        """
+        auth = self.make_user_auth("user", tenant_id)
+        with fake_tenantadm():
+            self.do_test_change_status(auth)

--- a/tests/tests/test_put_devices.py
+++ b/tests/tests/test_put_devices.py
@@ -10,9 +10,9 @@ class TestPrebootstrap(ManagementClient):
         Status = self.client.get_model('Status')
         s = Status(status=expected_final)
         try:
-            actual_initial = self.client.devices.get_devices_id(id=device_id, _request_options=self.uauth).result()[0].status
+            actual_initial = self.client.devices.get_devices_id(id=device_id, _request_options={"headers": auth}).result()[0].status
             assert actual_initial == expected_initial
-            self.client.devices.put_devices_id_status(id=device_id, status=s, _request_options=self.uauth).result()
+            self.client.devices.put_devices_id_status(id=device_id, status=s, _request_options={"headers": auth}).result()
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == expected_error_code
             return
@@ -21,7 +21,7 @@ class TestPrebootstrap(ManagementClient):
                 pytest.fail("Expected an exception, but didnt get any!")
                 return
 
-        assert self.client.devices.get_devices_id(id=device_id, _request_options=self.uauth).result()[0].status == expected_final
+        assert self.client.devices.get_devices_id(id=device_id, _request_options={"headers": auth}).result()[0].status == expected_final
 
 
     def test_change_status(self):

--- a/tests/tests/test_put_devices.py
+++ b/tests/tests/test_put_devices.py
@@ -6,7 +6,9 @@ import pytest
 @pytest.mark.usefixtures("create_devices")
 class TestPrebootstrap(ManagementClient):
 
-    def change_status(self, device_id, expected_initial, expected_final, expected_error_code=None):
+    def change_status(self, device_id, expected_initial, expected_final, expected_error_code=None, auth=None):
+        if auth is None:
+            auth = self.uauth
         Status = self.client.get_model('Status')
         s = Status(status=expected_final)
         try:


### PR DESCRIPTION
Issues: MEN-1074

this introduces multitenancy across all acceptance tests. considerable infrastructure changes had to be introduced, like fake `tenantadm` service and splitting single-tenant vs multi-tenant tests in compose/travis.

the ad-hoc `tenantadm` implementation can be replaced with the one in https://github.com/mendersoftware/deviceauth/pull/135 at some point. 

@bboozzoo @mendersoftware/rndity 

EDIT: this needs https://github.com/mendersoftware/deviceauth/pull/135 to pass (tested locally with a patched `deviceauth`). more specifically this commit is required:

https://github.com/mendersoftware/deviceauth/pull/135/commits/f3b2f401bd5a40664c589cea597804d21f3cb127





