### PR TITLE
Changelog: Additional MongoDB configuration options: mongo_ssl, mongo…

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,15 @@ const (
 	SettingDb        = "mongo"
 	SettingDbDefault = "mongo-device-adm:27017"
 
+	SettingDbSSL        = "mongo_ssl"
+	SettingDbSSLDefault = false
+
+	SettingDbSSLSkipVerify        = "mongo_ssl_skipverify"
+	SettingDbSSLSkipVerifyDefault = false
+
+	SettingDbUsername = "mongo_username"
+	SettingDbPassword = "mongo_password"
+
 	SettingDevAuthUrl        = "devauthurl"
 	SettingDevAuthUrlDefault = "http://mender-device-auth:8080"
 )
@@ -38,5 +47,7 @@ var (
 		{Key: SettingMiddleware, Value: SettingMiddlewareDefault},
 		{Key: SettingDb, Value: SettingDbDefault},
 		{Key: SettingDevAuthUrl, Value: SettingDevAuthUrlDefault},
+		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
+		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},
 	}
 )

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,57 @@
-    # HTTP Server middleware environment
-    # Available values:
-    #   dev
-    #       development environment
-    #   prod
-    #       production environment
-    #
-    # Defaults to: prod
-#middleware: dev
+# API server listen address
+# Defauls to: ":8080" which will listen on all avalable interfaces.
+# Overwrite with environment variable: DEVICEADM_LISTEN
+
+# listen: :8080
+
+# HTTP Server middleware environment
+# Available values:
+#   dev
+#       development environment
+#   prod
+#       production environment
+# Defaults to: prod
+# Overwrite with environment variable: DEVICEADM_MIDDLEWARE
+
+# middleware: dev
+
+# Mongodb connection string
+# Defaults to: mongo-device-adm:27017
+# Overwrite with environment variable: DEVICEADM_MONGO
+
+# mongo: mongo-device-adm:27017
+
+# Enable SSL for mongo connections
+# Defaults to: false
+# Overwrite with environment variable: DEVICEADM_MONGO_SSL
+
+# mongo_ssl: false
+
+# SkipVerify controls whether a mongo client verifies the
+# server's certificate chain and host name.
+# If InsecureSkipVerify is true, accepts any certificate
+# presented by the server and any host name in that certificate.
+# Defaults to: false
+# Overwrite with environment variable: DEVICEADM_MONGO_SSL_SKIPVERIFY
+
+# mongo_ssl_skipverify: false
+
+# Mongodb username
+# Overwrites username set in connection string.
+# Defaults to: none
+# Overwrite with environment variable: DEVICEADM_MONGO_USERNAME
+
+# mongo_username: user
+
+# Mongodb password
+# Overwrites password set in connection string.
+# Defaults to: none
+# Overwrite with environment variable: DEVICEADM_MONGO_PASSWORD
+
+# mongo_password: secret
+
+# Device AUTH service address
+# Defaults to: http://mender-device-auth:8080
+# Overwrite with environment variable: DEVICEADM_DEVAUTHURL
+
+# devauthurl: http://mender-device-auth:8080

--- a/main.go
+++ b/main.go
@@ -62,7 +62,17 @@ func main() {
 	l.Printf("Device Admission Service, version %s starting up",
 		CreateVersionString())
 
-	db, err := mongo.NewDataStoreMongo(conf.GetString(SettingDb))
+	db, err := mongo.NewDataStoreMongo(
+		mongo.DataStoreMongoConfig{
+			ConnectionString: conf.GetString(SettingDb),
+
+			SSL:           conf.GetBool(SettingDbSSL),
+			SSLSkipVerify: conf.GetBool(SettingDbSSLSkipVerify),
+
+			Username: conf.GetString(SettingDbUsername),
+			Password: conf.GetString(SettingDbPassword),
+		})
+
 	if err != nil {
 		l.Fatal("failed to connect to db")
 	}

--- a/server.go
+++ b/server.go
@@ -46,7 +46,16 @@ func RunServer(c config.Reader) error {
 
 	l := log.New(log.Ctx{})
 
-	d, err := mongo.NewDataStoreMongo(c.GetString(SettingDb))
+	d, err := mongo.NewDataStoreMongo(
+		mongo.DataStoreMongoConfig{
+			ConnectionString: c.GetString(SettingDb),
+
+			SSL:           c.GetBool(SettingDbSSL),
+			SSLSkipVerify: c.GetBool(SettingDbSSLSkipVerify),
+
+			Username: c.GetString(SettingDbUsername),
+			Password: c.GetString(SettingDbPassword),
+		})
 	if err != nil {
 		return errors.Wrap(err, "database connection failed")
 	}


### PR DESCRIPTION
…_ssl_skipverify, mongo_username, mongo_password

Allow to connect to MongoDB over TLS (if configured).
Additional options for specifying user/pass for cleaner management of secrets.

Improve config docs.

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>