### PR TITLE
ensure db indexes on all write operations

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -222,6 +222,11 @@ func genDeviceAuthUpdate(dev *model.DeviceAuth) *model.DeviceAuth {
 func (db *DataStoreMongo) PutDeviceAuth(ctx context.Context, dev *model.DeviceAuth) error {
 	s := db.session.Copy()
 	defer s.Close()
+
+	if err := db.EnsureIndexes(ctx, s); err != nil {
+		return err
+	}
+
 	c := s.DB(ctx_store.DbFromContext(ctx, DbName)).C(DbDevicesColl)
 
 	filter := bson.M{"id": dev.ID}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -31,9 +31,11 @@ import (
 )
 
 const (
-	DbVersion     = "1.1.0"
-	DbName        = "deviceadm"
-	DbDevicesColl = "devices"
+	DbVersion           = "1.1.0"
+	DbName              = "deviceadm"
+	DbDevicesColl       = "devices"
+	dbDeviceIdIndex     = "id"
+	dbDeviceIdIndexName = "uniqueDeviceIdIndex"
 )
 
 type DataStoreMongo struct {
@@ -258,4 +260,17 @@ func (db *DataStoreMongo) Migrate(ctx context.Context, version string) error {
 	}
 
 	return nil
+}
+
+func (db *DataStoreMongo) EnsureIndexes(ctx context.Context, s *mgo.Session) error {
+	uniqueDevIdIdx := mgo.Index{
+		Key:        []string{dbDeviceIdIndex},
+		Unique:     true,
+		Name:       dbDeviceIdIndexName,
+		Background: false,
+	}
+
+	return s.DB(ctx_store.DbFromContext(ctx, DbName)).
+		C(DbDevicesColl).EnsureIndex(uniqueDevIdIdx)
+
 }

--- a/store/mongo/migration_1_1_0.go
+++ b/store/mongo/migration_1_1_0.go
@@ -19,14 +19,8 @@ import (
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
 	ctx_store "github.com/mendersoftware/go-lib-micro/store"
 	"github.com/pkg/errors"
-	"gopkg.in/mgo.v2"
 
 	"github.com/mendersoftware/deviceadm/model"
-)
-
-const (
-	dbDeviceIdIndex     = "id"
-	dbDeviceIdIndexName = "uniqueDeviceIdIndex"
 )
 
 type migration_1_1_0 struct {
@@ -64,24 +58,11 @@ func (m *migration_1_1_0) Up(from migrate.Version) error {
 		return errors.Wrap(err, "failed to close DB iterator")
 	}
 
-	if err := m.ensureIndexes(s); err != nil {
+	if err := m.ms.EnsureIndexes(m.ctx, s); err != nil {
 		return errors.Wrap(err, "database indexing failed")
 	}
 
 	return nil
-}
-
-func (m *migration_1_1_0) ensureIndexes(s *mgo.Session) error {
-	uniqueDevIdIdx := mgo.Index{
-		Key:        []string{dbDeviceIdIndex},
-		Unique:     true,
-		Name:       dbDeviceIdIndexName,
-		Background: false,
-	}
-
-	return s.DB(ctx_store.DbFromContext(m.ctx, DbName)).
-		C(DbDevicesColl).EnsureIndex(uniqueDevIdIdx)
-
 }
 
 func (m *migration_1_1_0) Version() migrate.Version {


### PR DESCRIPTION
Changes:
- move migrations to datastore;
- ensure indexes are created before upserting objects

https://tracker.mender.io/browse/MEN-1384

@maciejmrowiec @mendersoftware/rndity 